### PR TITLE
Add missing Create permission for AzureIdentity and AzureIdentityBinding

### DIFF
--- a/helm/cluster-api-provider-azure/templates/rbac.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.yaml
@@ -69,12 +69,24 @@ rules:
   - apiGroups:
       - aadpodidentity.k8s.io
     resources:
+      - azureidentities
+    verbs:
+      - create
+  - apiGroups:
+      - aadpodidentity.k8s.io
+    resources:
       - azureidentitybindings
       - azureidentitybindings/status
     verbs:
       - get
       - list
       - watch
+  - apiGroups:
+      - aadpodidentity.k8s.io
+    resources:
+      - azureidentitybindings
+    verbs:
+      - create
   - apiGroups:
       - cluster.x-k8s.io
     resources:


### PR DESCRIPTION
Kind of towards https://github.com/giantswarm/giantswarm/issues/16110, but more about just fixing RBAC role that CAPZ controller is using for aad-po-identity types, as it was missing `Create` permission for `AzureIdentity` and `AzureIdentityBinding` *.

\* [The ClusterRole in aad-po-identity manifests in CAPZ repo](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/config/default/aad-pod-identity-deployment.yaml#L40-L56) has `Create` permission for `AzureIdentity` and `AzureIdentityBinding`, and since both CAPZ controller and aad-pod-identity use the same service account (and therefore all roles from all bindings where that service account is used), CAPZ was also able to create these types.