### PR TITLE
Remove rbac proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.2.0
+  architect: giantswarm/architect@2.7.0
 
 workflows:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove kube-rbac-proxy for the metrics endpoint.
+
+### Fixed
+
+- Fixed label selector for webhook and manager services.
+
 [Unreleased]: https://github.com/giantswarm/cluster-api-provider-azure-app/tree/main

--- a/helm/cluster-api-provider-azure/templates/deployment.yaml
+++ b/helm/cluster-api-provider-azure/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "resource.default.name" . }}
       containers:
       - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=0.0.0.0:8080
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},AKS={{ .Values.featuregates.aks }}
         - --watch-filter={{ include "resource.app.version" . }}
         env:
@@ -77,18 +77,11 @@ spec:
         - containerPort: 9440
           name: healthz
           protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /readyz
             port: healthz
-      - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: "{{ .Values.kuberbacproxy.image.registry }}/{{ .Values.kuberbacproxy.image.name }}:{{ .Values.kuberbacproxy.image.tag }}"
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
       terminationGracePeriodSeconds: 10

--- a/helm/cluster-api-provider-azure/templates/rbac.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.yaml
@@ -280,26 +280,6 @@ rules:
       - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    {{ include "labels.provider" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy
-rules:
-  - apiGroups:
-      - authentication.k8s.io
-    resources:
-      - tokenreviews
-    verbs:
-      - create
-  - apiGroups:
-      - authorization.k8s.io
-    resources:
-      - subjectaccessreviews
-    verbs:
-      - create
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
@@ -325,21 +305,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "resource.default.name" . }}
-subjects:
-- kind: ServiceAccount
-  name: {{ include "resource.default.name" . }}
-  namespace: {{ include "resource.default.namespace" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    {{ include "labels.provider" . | nindent 4 }}
-  name: {{ include "resource.default.name" . }}-proxy
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "resource.default.name" . }}-proxy
 subjects:
 - kind: ServiceAccount
   name: {{ include "resource.default.name" . }}

--- a/helm/cluster-api-provider-azure/templates/service.yaml
+++ b/helm/cluster-api-provider-azure/templates/service.yaml
@@ -3,17 +3,17 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
-  labels:
     giantswarm.io/monitoring: "true"
+  labels:
     control-plane: capz-controller-manager
     {{- include "labels.common" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-metrics
   namespace: {{ include "resource.default.namespace" . }}
 spec:
   ports:
-  - name: https
-    port: 8443
-    targetPort: https
+  - name: metrics
+    port: 8080
+    targetPort: metrics
   selector:
     {{- include "labels.selector" . | nindent 4 }}
     control-plane: capz-controller-manager

--- a/helm/cluster-api-provider-azure/templates/service.yaml
+++ b/helm/cluster-api-provider-azure/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "8080"
   labels:
     control-plane: capz-controller-manager
     {{- include "labels.common" . | nindent 4 }}

--- a/helm/cluster-api-provider-azure/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-provider-azure/templates/webhook/deployment.yaml
@@ -12,29 +12,19 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
-      control-plane: capz-controller-manager
+      control-plane: capz-controller-manager-webhook
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-logs-container: manager
       labels:
         aadpodidbinding: capz-controller-aadpodidentity-selector
-        control-plane: capz-controller-manager
+        control-plane: capz-controller-manager-webhook
         {{- include "labels.common" . | nindent 8 }}
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-      - args:
-        - --metrics-addr=127.0.0.1:8080
+        - --metrics-addr=0.0.0.0:8080
         - --webhook-port=9443
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},AKS={{ .Values.featuregates.aks }}
         env:
@@ -63,6 +53,9 @@ spec:
           protocol: TCP
         - containerPort: 9440
           name: healthz
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
           protocol: TCP
         readinessProbe:
           httpGet:

--- a/helm/cluster-api-provider-azure/templates/webhook/service.yaml
+++ b/helm/cluster-api-provider-azure/templates/webhook/service.yaml
@@ -1,6 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    prometheus.io/scrape: "true"
+    giantswarm.io/monitoring: "true"
+    giantswarm.io/monitoring-port: "8080"
   labels:
     {{- include "labels.common" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-webhook
@@ -11,3 +15,4 @@ spec:
     targetPort: webhook-server
   selector:
     {{- include "labels.selector" . | nindent 4 }}
+    control-plane: capz-controller-manager-webhook

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -4,12 +4,6 @@ image:
   name: giantswarm/cluster-api-azure-controller
   tag: ffb4ce34b9fdfd8c52f2429af4d4cd7f0e2ec1b7
 
-kuberbacproxy:
-  image:
-    registry: gcr.io
-    name: kubebuilder/kube-rbac-proxy
-    tag: v0.8.0
-
 featuregates:
   machinepool: true
   aks: false


### PR DESCRIPTION
According to upstream direction (https://github.com/kubernetes-sigs/cluster-api/issues/4679) this PR removes the rbac proxy from the metrics endpoint.
We don't use it anywhere else and it's just better to not have it for conformity