### PR TITLE
Only push to catalog when tagging since we no longer use shas

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,15 @@ workflows:
       - architect/push-to-app-catalog:
           context: architect
           name: push-to-app-catalog
-          app_catalog: "control-plane-test-catalog"
+          app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "cluster-api-provider-azure"
+          filters:
+            # Only do this when a new tag is created.
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 
       - architect/push-to-app-collection:
           name: push-cluster-api-provider-azure-to-azure-app-collection


### PR DESCRIPTION
[From circleci docs](https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag)
> CircleCI does not run workflows for tags unless you explicitly specify tag filters.

So this app was not being pushed to the catalog when a new tag was being created, and because of that it was not being published to the collection.