### PR TITLE
Use right parameters for selected image tag

### DIFF
--- a/helm/cluster-api-provider-azure/templates/deployment.yaml
+++ b/helm/cluster-api-provider-azure/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ include "resource.default.name" . }}
       containers:
       - args:
-        - --metrics-bind-addr=0.0.0.0:8080
+        - --metrics-addr=0.0.0.0:8080
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},AKS={{ .Values.featuregates.aks }}
         - --watch-filter={{ include "resource.app.version" . }}
         env:

--- a/helm/cluster-api-provider-azure/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-provider-azure/templates/webhook/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - args:
-        - --metrics-bind-addr=0.0.0.0:8080
+        - --metrics-addr=0.0.0.0:8080
         - --webhook-port=9443
         - --feature-gates=MachinePool={{ .Values.featuregates.machinepool }},AKS={{ .Values.featuregates.aks }}
         env:


### PR DESCRIPTION
Trying to deploy this app to our MCs, pods fail with `unknown flag: --metrics-bind-addr`. That parameter is the one used in latest capz releases, but the release selected here in the `image.tag` helm value is using the old `--metrics-addr`.