### PR TITLE
Bump upstream to 0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed label selector for webhook and manager services.
 
 [Unreleased]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.2...HEAD
-[0.5.2]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.2...v0.5.2
 [0.5.2]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.4.12-gsalpha3...v0.5.2
 [0.4.12-gsalpha3]: https://github.com/giantswarm/cluster-api-provider-azure-app/releases/tag/v0.4.12-gsalpha3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add non-exp apiGroups to ClusterRole.
+
 ### Changed
 
 - Bumped `cluster-api-azure-controller` to version `v0.5.3` (vanilla upstream version).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.3] - 2021-09-29
+### Changed
+
+- Bumped `cluster-api-azure-controller` to version `v0.5.3` (vanilla upstream version).
 
 ## [0.5.2] - 2021-09-29
 
@@ -40,8 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed label selector for webhook and manager services.
 
-[Unreleased]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.3...HEAD
-[0.5.3]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.2...v0.5.3
+[Unreleased]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.2...HEAD
 [0.5.2]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.5.2...v0.5.2
 [0.5.2]: https://github.com/giantswarm/cluster-api-provider-azure-app/compare/v0.4.12-gsalpha3...v0.5.2
 [0.4.12-gsalpha3]: https://github.com/giantswarm/cluster-api-provider-azure-app/releases/tag/v0.4.12-gsalpha3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Add non-exp apiGroups to ClusterRole.
-
 ### Changed
 
 - Bumped `cluster-api-azure-controller` to version `v0.5.3` (vanilla upstream version).

--- a/helm/cluster-api-provider-azure/templates/rbac.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.yaml
@@ -118,7 +118,6 @@ rules:
       - watch
   - apiGroups:
       - exp.cluster.x-k8s.io
-      - cluster.x-k8s.io
     resources:
       - machinepools
       - machinepools/status
@@ -128,7 +127,6 @@ rules:
       - watch
   - apiGroups:
       - exp.infrastructure.cluster.x-k8s.io
-      - infrastructure.cluster.x-k8s.io
     resources:
       - azuremachinepools
       - azuremachinepools/status

--- a/helm/cluster-api-provider-azure/templates/rbac.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.yaml
@@ -118,6 +118,7 @@ rules:
       - watch
   - apiGroups:
       - exp.cluster.x-k8s.io
+      - cluster.x-k8s.io
     resources:
       - machinepools
       - machinepools/status
@@ -127,6 +128,7 @@ rules:
       - watch
   - apiGroups:
       - exp.infrastructure.cluster.x-k8s.io
+      - infrastructure.cluster.x-k8s.io
     resources:
       - azuremachinepools
       - azuremachinepools/status

--- a/helm/cluster-api-provider-azure/templates/rbac.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.yaml
@@ -94,6 +94,7 @@ rules:
       - clusters
       - clusters/status
       - machinepools
+      - machinepools/status
     verbs:
       - get
       - list

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v0.5.2
+  tag: v0.5.3
 
 featuregates:
   machinepool: true


### PR DESCRIPTION
I also deleted release 0.5.3 from the changelog cc @fiunchinho 