### PR TITLE
Restart azure-operator after ensuring CRDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Restart azure-operator after ensuring CRDs because sometimes reconciliation stops.
+
 ## [1.1.0] - 2022-03-21
 
 ### Added

--- a/helm/cluster-api-provider-azure/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-provider-azure/templates/crd-install/crd-job.yaml
@@ -38,6 +38,12 @@ spec:
           # in the pod's logs.
 
           kubectl apply -k /files 2>&1
+
+          # After updating CRDs the azure-operator will sometimes stop reconciling CRDs,
+          # so here we mitigate that issue by restarting it.
+          for deployment in $(kubectl get deployment -l app.kubernetes.io/name=azure-operator -o name); do
+            kubectl rollout restart -n giantswarm "$deployment"
+          done
         volumeMounts:
 {{- range $path, $_ := $.Files.Glob "files/**.yaml" }}
         - name: {{ printf "%s-%s" (base (dir $path)) (trimSuffix "-yaml" (base $path | replace "." "-")) | trunc 63 | trimSuffix "-" }}

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -8,8 +8,6 @@ project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 
-watchfilter: capi
-
 crdInstall:
   enable: true
   kubectl:


### PR DESCRIPTION
After ensuring CRDs, sometimes our controllers stop reconciling. We need to restart them.