### PR TITLE
Upstream update to v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `PodSecurityPolicy` are removed on newer k8s versions, so only apply it in the `crd-install` job if object is registered in the k8s API.
+- Update upstream cluster-api-provider-azure version from v1.0.1 to v1.1.3 (see highlights bellow).
+- [CAPZ v1.1.3] Add new AzureClusterIdentity type - `ManualServicePrincipal`.
+- [CAPZ v1.1.3] Add namespace listing permission to `ClusterRole` `capz-manager-role`.
 
 ### Added
 

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'
@@ -110,9 +110,15 @@ spec:
       subresources:
         status: {}
     - additionalPrinterColumns:
-        - description: AzureMachine ready status
-          jsonPath: .status.ready
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
           name: Ready
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+          name: Reason
+          type: string
+        - jsonPath: .status.conditions[?(@.type=='Ready')].message
+          name: Message
+          priority: 1
           type: string
         - description: Azure VM provisioning state
           jsonPath: .status.vmState

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -79,6 +79,7 @@
               description: UserAssignedMSI or Service Principal
               enum:
                 - ServicePrincipal
+                - ManualServicePrincipal
                 - UserAssignedMSI
               type: string
           required:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -59,7 +59,7 @@
                           description: NatGateway associated with this subnet.
                           properties:
                             id:
-                              description: ID is the Azure resource ID of the nat gateway. READ-ONLY
+                              description: ID is the Azure resource ID of the NAT gateway. READ-ONLY
                               type: string
                             ip:
                               description: PublicIPSpec defines the inputs to create an Azure public IP address.
@@ -440,7 +440,7 @@
                         description: NatGateway associated with this subnet.
                         properties:
                           id:
-                            description: ID is the Azure resource ID of the nat gateway. READ-ONLY
+                            description: ID is the Azure resource ID of the NAT gateway. READ-ONLY
                             type: string
                           ip:
                             description: PublicIPSpec defines the inputs to create an Azure public IP address.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -205,7 +205,7 @@
           description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
           properties:
             initialized:
-              description: Initialized is true when the the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
+              description: Initialized is true when the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
               type: boolean
             longRunningOperationStates:
               description: LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -15,6 +15,15 @@
         spec:
           description: AzureManagedMachinePoolSpec defines the desired state of AzureManagedMachinePool.
           properties:
+            availabilityZones:
+              description: AvailabilityZones - Availability zones for nodes. Must use VirtualMachineScaleSets AgentPoolType.
+              items:
+                type: string
+              type: array
+            maxPods:
+              description: MaxPods specifies the kubelet --max-pods configuration for the node pool.
+              format: int32
+              type: integer
             mode:
               description: 'Mode - represents mode of an agent pool. Possible values include: System, User.'
               enum:
@@ -33,6 +42,16 @@
               items:
                 type: string
               type: array
+            scaling:
+              description: Scaling specifies the autoscaling parameters for the node pool.
+              properties:
+                maxSize:
+                  format: int32
+                  type: integer
+                minSize:
+                  format: int32
+                  type: integer
+              type: object
             sku:
               description: SKU is the size of the VMs in the node pool.
               type: string

--- a/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
@@ -27,6 +27,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.0.1
+  tag: v1.1.3
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

- Update upstream cluster-api-provider-azure version from v1.0.1 to v1.1.3.
- Highlighted manifest/charts changes pulled in from upstream:
  - Add new AzureClusterIdentity type - `ManualServicePrincipal`.
  - Add namespace listing permission to `ClusterRole` `capz-manager-role`.

Upstream release notes:
- [v1.1.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.1.0)
- [v1.1.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.1.1)
- [v1.1.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.1.2)
- [v1.1.3](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.1.3)

P.S. Hydra sorry for the ping, we will update repo ownership so you don't get these.