### PR TITLE
Upstream update to v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Set CRD kubebuilder version in helm template.
+- Update upstream cluster-api-provider-azure version from v1.1.3 to v1.2.1 (see highlights bellow).
+- Generate values.schema.json.
 
 ## [1.2.0] - 2022-12-08
 

--- a/config/helm/webhook-watchfilter.yaml
+++ b/config/helm/webhook-watchfilter.yaml
@@ -8,6 +8,10 @@ webhooks:
     objectSelector:
       matchLabels:
         cluster.x-k8s.io/watch-filter: capi
+  - name: default.azureclustertemplate.infrastructure.cluster.x-k8s.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: capi
   - name: default.azuremachine.infrastructure.cluster.x-k8s.io
     objectSelector:
       matchLabels:
@@ -38,6 +42,10 @@ webhooks:
     objectSelector:
       matchLabels:
         cluster.x-k8s.io/watch-filter: capi
+  - name: validation.azureclustertemplate.infrastructure.cluster.x-k8s.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: capi
   - name: validation.azuremachine.infrastructure.cluster.x-k8s.io
     objectSelector:
       matchLabels:
@@ -51,6 +59,10 @@ webhooks:
       matchLabels:
         cluster.x-k8s.io/watch-filter: capi
   - name: azuremachinepoolmachine.kb.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: capi
+  - name: validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io
     objectSelector:
       matchLabels:
         cluster.x-k8s.io/watch-filter: capi

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
+    controller-gen.kubebuilder.io/version: '{{- include "annotations.kubebuilder_version" . -}}'
+  labels:
+    app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+    app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+    app.kubernetes.io/instance: '{{ .Release.Name }}'
+    app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+    app.kubernetes.io/name: cluster-api-provider-azure
+    app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
+    cluster.x-k8s.io/provider: infrastructure-azure
+    cluster.x-k8s.io/v1beta1: v1beta1
+    helm.sh/chart: cluster-api-provider-azure
+  name: azureclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        caBundle: Cg==
+        service:
+          name: capz-webhook-service
+          namespace: '{{ .Release.Namespace }}'
+          path: /convert
+          port: 443
+      conversionReviewVersions:
+        - v1
+        - v1beta1
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+      - cluster-api
+    kind: AzureClusterTemplate
+    listKind: AzureClusterTemplateList
+    plural: azureclustertemplates
+    singular: azureclustertemplate
+  scope: Namespaced
+  versions:
+    - name: v1beta1
+      schema: {}
+      served: true
+      storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/kustomization.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/kustomization.yaml
@@ -1,6 +1,7 @@
 resources:
   - bases/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
   - bases/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+  - bases/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
   - bases/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
   - bases/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
   - bases/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -45,6 +46,12 @@ patches:
       version: v1
       kind: CustomResourceDefinition
       name: azureclusters.infrastructure.cluster.x-k8s.io
+  - path: patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+    target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: azureclustertemplates.infrastructure.cluster.x-k8s.io
   - path: patches/versions/v1alpha4/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
     target:
       group: apiextensions.k8s.io

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -107,7 +107,7 @@
                     description: SubnetSpec configures an Azure subnet.
                     properties:
                       cidrBlock:
-                        description: 'CidrBlock is the CIDR block to be used when the provider creates a managed Vnet. DEPRECATED: Use CIDRBlocks instead'
+                        description: 'CidrBlock is the CIDR block to be used when the provider creates a managed Vnet. Deprecated: Use CIDRBlocks instead'
                         type: string
                       cidrBlocks:
                         description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
@@ -189,7 +189,7 @@
                   description: Vnet is the configuration for the Azure virtual network.
                   properties:
                     cidrBlock:
-                      description: 'CidrBlock is the CIDR block to be used when the provider creates a managed virtual network. DEPRECATED: Use CIDRBlocks instead'
+                      description: 'CidrBlock is the CIDR block to be used when the provider creates a managed virtual network. Deprecated: Use CIDRBlocks instead'
                       type: string
                     cidrBlocks:
                       description: CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -27,7 +27,7 @@
               description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
               type: boolean
             availabilityZone:
-              description: 'DEPRECATED: use FailureDomain instead'
+              description: 'Deprecated: use FailureDomain instead'
               properties:
                 enabled:
                   type: boolean
@@ -153,7 +153,7 @@
                   type: object
               type: object
             location:
-              description: 'DEPRECATED: to support old clients, will be removed in v1alpha4/v1beta1'
+              description: 'Deprecated: to support old clients, will be removed in v1alpha4/v1beta1'
               type: string
             osDisk:
               description: OSDisk specifies the parameters for the operating system disk of the machine

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -33,7 +33,7 @@
                       description: AllocatePublicIP allows the ability to create dynamic public ips for machines where this value is true.
                       type: boolean
                     availabilityZone:
-                      description: 'DEPRECATED: use FailureDomain instead'
+                      description: 'Deprecated: use FailureDomain instead'
                       properties:
                         enabled:
                           type: boolean
@@ -159,7 +159,7 @@
                           type: object
                       type: object
                     location:
-                      description: 'DEPRECATED: to support old clients, will be removed in v1alpha4/v1beta1'
+                      description: 'Deprecated: to support old clients, will be removed in v1alpha4/v1beta1'
                       type: string
                     osDisk:
                       description: OSDisk specifies the parameters for the operating system disk of the machine

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -78,6 +78,10 @@
                           type: object
                         role:
                           description: Role defines the subnet role (eg. Node, ControlPlane)
+                          enum:
+                            - node
+                            - control-plane
+                            - bastion
                           type: string
                         routeTable:
                           description: RouteTable defines the route table that should be attached to this subnet.
@@ -236,7 +240,7 @@
                   type: array
               type: object
             controlPlaneEndpoint:
-              description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
+              description: ControlPlaneEndpoint represents the endpoint used to communicate with the control plane. It is not recommended to set this when creating an AzureCluster as CAPZ will set this for you. However, if it is set, CAPZ will not change it.
               properties:
                 host:
                   description: The hostname on which the API server is serving.
@@ -459,6 +463,10 @@
                         type: object
                       role:
                         description: Role defines the subnet role (eg. Node, ControlPlane)
+                        enum:
+                          - node
+                          - control-plane
+                          - bastion
                         type: string
                       routeTable:
                         description: RouteTable defines the route table that should be attached to this subnet.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -1,0 +1,392 @@
+- op: replace
+  path: /spec/versions/0/schema
+  value:
+    openAPIV3Schema:
+      description: AzureClusterTemplate is the Schema for the azureclustertemplates API.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AzureClusterTemplateSpec defines the desired state of AzureClusterTemplate.
+          properties:
+            template:
+              description: AzureClusterTemplateResource describes the data needed to create an AzureCluster from a template.
+              properties:
+                spec:
+                  properties:
+                    additionalTags:
+                      additionalProperties:
+                        type: string
+                      description: AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.
+                      type: object
+                    azureEnvironment:
+                      description: 'AzureEnvironment is the name of the AzureCloud to be used. The default value that would be used by most users is "AzurePublicCloud", other values are: - ChinaCloud: "AzureChinaCloud" - GermanCloud: "AzureGermanCloud" - PublicCloud: "AzurePublicCloud" - USGovernmentCloud: "AzureUSGovernmentCloud"'
+                      type: string
+                    bastionSpec:
+                      description: BastionSpec encapsulates all things related to the Bastions in the cluster.
+                      properties:
+                        azureBastion:
+                          properties:
+                            subnet:
+                              properties:
+                                cidrBlocks:
+                                  description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
+                                  items:
+                                    type: string
+                                  type: array
+                                natGateway:
+                                  description: NatGateway associated with this subnet.
+                                  properties:
+                                    name:
+                                      type: string
+                                  required:
+                                    - name
+                                  type: object
+                                role:
+                                  description: Role defines the subnet role (eg. Node, ControlPlane)
+                                  enum:
+                                    - node
+                                    - control-plane
+                                    - bastion
+                                  type: string
+                                securityGroup:
+                                  description: SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
+                                  properties:
+                                    securityRules:
+                                      description: SecurityRules is a slice of Azure security rules for security groups.
+                                      items:
+                                        description: SecurityRule defines an Azure security rule for security groups.
+                                        properties:
+                                          description:
+                                            description: A description for this rule. Restricted to 140 chars.
+                                            type: string
+                                          destination:
+                                            description: Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                                            type: string
+                                          destinationPorts:
+                                            description: DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                            type: string
+                                          direction:
+                                            description: Direction indicates whether the rule applies to inbound, or outbound traffic. "Inbound" or "Outbound".
+                                            enum:
+                                              - Inbound
+                                              - Outbound
+                                            type: string
+                                          name:
+                                            description: Name is a unique name within the network security group.
+                                            type: string
+                                          priority:
+                                            description: Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.
+                                            format: int32
+                                            type: integer
+                                          protocol:
+                                            description: Protocol specifies the protocol type. "Tcp", "Udp", "Icmp", or "*".
+                                            enum:
+                                              - Tcp
+                                              - Udp
+                                              - Icmp
+                                              - '*'
+                                            type: string
+                                          source:
+                                            description: Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
+                                            type: string
+                                          sourcePorts:
+                                            description: SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                            type: string
+                                        required:
+                                          - description
+                                          - direction
+                                          - name
+                                          - protocol
+                                        type: object
+                                      type: array
+                                    tags:
+                                      additionalProperties:
+                                        type: string
+                                      description: Tags defines a map of tags.
+                                      type: object
+                                  type: object
+                              required:
+                                - role
+                              type: object
+                          type: object
+                      type: object
+                    cloudProviderConfigOverrides:
+                      description: 'CloudProviderConfigOverrides is an optional set of configuration values that can be overridden in azure cloud provider config. This is only a subset of options that are available in azure cloud provider config. Some values for the cloud provider config are inferred from other parts of cluster api provider azure spec, and may not be available for overrides. See: https://kubernetes-sigs.github.io/cloud-provider-azure/install/configs Note: All cloud provider config values can be customized by creating the secret beforehand. CloudProviderConfigOverrides is only used when the secret is managed by the Azure Provider.'
+                      properties:
+                        backOffs:
+                          description: BackOffConfig indicates the back-off config options.
+                          properties:
+                            cloudProviderBackoff:
+                              type: boolean
+                            cloudProviderBackoffDuration:
+                              type: integer
+                            cloudProviderBackoffExponent:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            cloudProviderBackoffJitter:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            cloudProviderBackoffRetries:
+                              type: integer
+                          type: object
+                        rateLimits:
+                          items:
+                            description: 'RateLimitSpec represents the rate limit configuration for a particular kind of resource. Eg. loadBalancerRateLimit is used to configure rate limits for load balancers. This eventually gets converted to CloudProviderRateLimitConfig that cloud-provider-azure expects. See: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/d585c2031925b39c925624302f22f8856e29e352/pkg/provider/azure_ratelimit.go#L25 We cannot use CloudProviderRateLimitConfig directly because floating point values are not supported in controller-tools. See: https://github.com/kubernetes-sigs/controller-tools/issues/245'
+                            properties:
+                              config:
+                                description: RateLimitConfig indicates the rate limit config options.
+                                properties:
+                                  cloudProviderRateLimit:
+                                    type: boolean
+                                  cloudProviderRateLimitBucket:
+                                    type: integer
+                                  cloudProviderRateLimitBucketWrite:
+                                    type: integer
+                                  cloudProviderRateLimitQPS:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  cloudProviderRateLimitQPSWrite:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              name:
+                                description: Name is the name of the rate limit spec.
+                                enum:
+                                  - defaultRateLimit
+                                  - routeRateLimit
+                                  - subnetsRateLimit
+                                  - interfaceRateLimit
+                                  - routeTableRateLimit
+                                  - loadBalancerRateLimit
+                                  - publicIPAddressRateLimit
+                                  - securityGroupRateLimit
+                                  - virtualMachineRateLimit
+                                  - storageAccountRateLimit
+                                  - diskRateLimit
+                                  - snapshotRateLimit
+                                  - virtualMachineScaleSetRateLimit
+                                  - virtualMachineSizesRateLimit
+                                  - availabilitySetRateLimit
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                      type: object
+                    identityRef:
+                      description: IdentityRef is a reference to an AzureIdentity to be used when reconciling this cluster
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                          type: string
+                        kind:
+                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                          type: string
+                        resourceVersion:
+                          description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        uid:
+                          description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                          type: string
+                      type: object
+                    location:
+                      type: string
+                    networkSpec:
+                      description: NetworkSpec encapsulates all things related to Azure network.
+                      properties:
+                        apiServerLB:
+                          description: APIServerLB is the configuration for the control-plane load balancer.
+                          properties:
+                            idleTimeoutInMinutes:
+                              description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
+                              format: int32
+                              type: integer
+                            sku:
+                              description: SKU defines an Azure load balancer SKU.
+                              type: string
+                            type:
+                              description: LBType defines an Azure load balancer Type.
+                              type: string
+                          type: object
+                        controlPlaneOutboundLB:
+                          description: ControlPlaneOutboundLB is the configuration for the control-plane outbound load balancer. This is different from APIServerLB, and is used only in private clusters (optionally) for enabling outbound traffic.
+                          properties:
+                            idleTimeoutInMinutes:
+                              description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
+                              format: int32
+                              type: integer
+                            sku:
+                              description: SKU defines an Azure load balancer SKU.
+                              type: string
+                            type:
+                              description: LBType defines an Azure load balancer Type.
+                              type: string
+                          type: object
+                        nodeOutboundLB:
+                          description: NodeOutboundLB is the configuration for the node outbound load balancer.
+                          properties:
+                            idleTimeoutInMinutes:
+                              description: IdleTimeoutInMinutes specifies the timeout for the TCP idle connection.
+                              format: int32
+                              type: integer
+                            sku:
+                              description: SKU defines an Azure load balancer SKU.
+                              type: string
+                            type:
+                              description: LBType defines an Azure load balancer Type.
+                              type: string
+                          type: object
+                        privateDNSZoneName:
+                          description: PrivateDNSZoneName defines the zone name for the Azure Private DNS.
+                          type: string
+                        subnets:
+                          description: Subnets is the configuration for the control-plane subnet and the node subnet.
+                          items:
+                            properties:
+                              cidrBlocks:
+                                description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
+                                items:
+                                  type: string
+                                type: array
+                              natGateway:
+                                description: NatGateway associated with this subnet.
+                                properties:
+                                  name:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              role:
+                                description: Role defines the subnet role (eg. Node, ControlPlane)
+                                enum:
+                                  - node
+                                  - control-plane
+                                  - bastion
+                                type: string
+                              securityGroup:
+                                description: SecurityGroup defines the NSG (network security group) that should be attached to this subnet.
+                                properties:
+                                  securityRules:
+                                    description: SecurityRules is a slice of Azure security rules for security groups.
+                                    items:
+                                      description: SecurityRule defines an Azure security rule for security groups.
+                                      properties:
+                                        description:
+                                          description: A description for this rule. Restricted to 140 chars.
+                                          type: string
+                                        destination:
+                                          description: Destination is the destination address prefix. CIDR or destination IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used.
+                                          type: string
+                                        destinationPorts:
+                                          description: DestinationPorts specifies the destination port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                          type: string
+                                        direction:
+                                          description: Direction indicates whether the rule applies to inbound, or outbound traffic. "Inbound" or "Outbound".
+                                          enum:
+                                            - Inbound
+                                            - Outbound
+                                          type: string
+                                        name:
+                                          description: Name is a unique name within the network security group.
+                                          type: string
+                                        priority:
+                                          description: Priority is a number between 100 and 4096. Each rule should have a unique value for priority. Rules are processed in priority order, with lower numbers processed before higher numbers. Once traffic matches a rule, processing stops.
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          description: Protocol specifies the protocol type. "Tcp", "Udp", "Icmp", or "*".
+                                          enum:
+                                            - Tcp
+                                            - Udp
+                                            - Icmp
+                                            - '*'
+                                          type: string
+                                        source:
+                                          description: Source specifies the CIDR or source IP range. Asterix '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from.
+                                          type: string
+                                        sourcePorts:
+                                          description: SourcePorts specifies source port or range. Integer or range between 0 and 65535. Asterix '*' can also be used to match all ports.
+                                          type: string
+                                      required:
+                                        - description
+                                        - direction
+                                        - name
+                                        - protocol
+                                      type: object
+                                    type: array
+                                  tags:
+                                    additionalProperties:
+                                      type: string
+                                    description: Tags defines a map of tags.
+                                    type: object
+                                type: object
+                            required:
+                              - role
+                            type: object
+                          type: array
+                        vnet:
+                          description: Vnet is the configuration for the Azure virtual network.
+                          properties:
+                            cidrBlocks:
+                              description: CIDRBlocks defines the virtual network's address space, specified as one or more address prefixes in CIDR notation.
+                              items:
+                                type: string
+                              type: array
+                            peerings:
+                              description: Peerings defines a list of peerings of the newly created virtual network with existing virtual networks.
+                              items:
+                                properties:
+                                  remoteVnetName:
+                                    description: RemoteVnetName defines name of the remote virtual network.
+                                    type: string
+                                required:
+                                  - remoteVnetName
+                                type: object
+                              type: array
+                            tags:
+                              additionalProperties:
+                                type: string
+                              description: Tags is a collection of tags describing the resource.
+                              type: object
+                          type: object
+                      type: object
+                    subscriptionID:
+                      type: string
+                  required:
+                    - location
+                  type: object
+              required:
+                - spec
+              type: object
+          required:
+            - template
+          type: object
+      type: object

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -204,6 +204,36 @@
         status:
           description: AzureManagedControlPlaneStatus defines the observed state of AzureManagedControlPlane.
           properties:
+            conditions:
+              description: Conditions defines current service state of the AzureManagedControlPlane.
+              items:
+                description: Condition defines an observation of a Cluster API resource operational state.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about the transition. This field may be empty.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                    type: string
+                  severity:
+                    description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                    type: string
+                required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                type: object
+              type: array
             initialized:
               description: Initialized is true when the control plane is available for initial contact. This may occur before the control plane is fully ready. In the AzureManagedControlPlane implementation, these are identical.
               type: boolean

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -33,10 +33,22 @@
             name:
               description: Name - name of the agent pool. If not specified, CAPZ uses the name of the CR as the agent pool name.
               type: string
+            nodeLabels:
+              additionalProperties:
+                type: string
+              description: Node labels - labels for all of the nodes present in node pool
+              type: object
             osDiskSizeGB:
               description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
               format: int32
               type: integer
+            osDiskType:
+              default: Managed
+              description: OsDiskType specifies the OS disk type for each node in the pool. Allowed values are 'Ephemeral' and 'Managed'.
+              enum:
+                - Ephemeral
+                - Managed
+              type: string
             providerIDList:
               description: ProviderIDList is the unique identifier as specified by the cloud provider.
               items:
@@ -55,6 +67,29 @@
             sku:
               description: SKU is the size of the VMs in the node pool.
               type: string
+            taints:
+              description: Taints specifies the taints for nodes present in this agent pool.
+              items:
+                properties:
+                  effect:
+                    description: Effect specifies the effect for the taint
+                    enum:
+                      - NoSchedule
+                      - NoExecute
+                      - PreferNoSchedule
+                    type: string
+                  key:
+                    description: Key is the key of the taint
+                    type: string
+                  value:
+                    description: Value is the value of the taint
+                    type: string
+                required:
+                  - effect
+                  - key
+                  - value
+                type: object
+              type: array
           required:
             - mode
             - sku
@@ -62,12 +97,69 @@
         status:
           description: AzureManagedMachinePoolStatus defines the observed state of AzureManagedMachinePool.
           properties:
+            conditions:
+              description: Conditions defines current service state of the AzureManagedControlPlane.
+              items:
+                description: Condition defines an observation of a Cluster API resource operational state.
+                properties:
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status to another. This should be when the underlying condition changed. If that is not known, then using the time when the API field changed is acceptable.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about the transition. This field may be empty.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition in CamelCase. The specific API may choose whether or not this field is considered a guaranteed API. This field may not be empty.
+                    type: string
+                  severity:
+                    description: Severity provides an explicit classification of Reason code, so the users or machines can immediately understand the current situation and act accordingly. The Severity field MUST be set only when Status=False.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of condition in CamelCase or in foo.example.com/CamelCase. Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important.
+                    type: string
+                required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                type: object
+              type: array
             errorMessage:
               description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
               type: string
             errorReason:
               description: Any transient errors that occur during the reconciliation of Machines can be added as events to the Machine object and/or logged in the controller's output.
               type: string
+            longRunningOperationStates:
+              description: LongRunningOperationStates saves the states for Azure long-running operations so they can be continued on the next reconciliation loop.
+              items:
+                description: Future contains the data needed for an Azure long-running operation to continue across reconcile loops.
+                properties:
+                  data:
+                    description: Data is the base64 url encoded json Azure AutoRest Future.
+                    type: string
+                  name:
+                    description: Name is the name of the Azure resource. Together with the service name, this forms the unique identifier for the future.
+                    type: string
+                  resourceGroup:
+                    description: ResourceGroup is the Azure resource group for the resource.
+                    type: string
+                  serviceName:
+                    description: ServiceName is the name of the Azure service. Together with the name of the resource, this forms the unique identifier for the future.
+                    type: string
+                  type:
+                    description: Type describes the type of future, such as update, create, delete, etc.
+                    type: string
+                required:
+                  - data
+                  - name
+                  - serviceName
+                  - type
+                type: object
+              type: array
             ready:
               description: Ready is true when the provider resource is ready.
               type: boolean

--- a/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_zzz-capz-mutating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_zzz-capz-mutating-webhook-configuration.yaml
@@ -46,6 +46,31 @@ webhooks:
     service:
       name: capz-webhook-service
       namespace: '{{ .Release.Namespace }}'
+      path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azureclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: default.azureclustertemplate.infrastructure.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: capi
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azureclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capz-webhook-service
+      namespace: '{{ .Release.Namespace }}'
       path: /mutate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachine
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
@@ -46,6 +46,31 @@ webhooks:
     service:
       name: capz-webhook-service
       namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azureclustertemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.azureclustertemplate.infrastructure.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: capi
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - azureclustertemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capz-webhook-service
+      namespace: '{{ .Release.Namespace }}'
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremachine
   failurePolicy: Fail
   matchPolicy: Equivalent
@@ -136,6 +161,29 @@ webhooks:
     - UPDATE
     resources:
     - azuremachinepoolmachines
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capz-webhook-service
+      namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-azuremanagedcluster
+  failurePolicy: Fail
+  name: validation.azuremanagedclusters.infrastructure.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: capi
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - UPDATE
+    resources:
+    - azuremanagedclusters
   sideEffects: None
 - admissionReviewVersions:
   - v1

--- a/helm/cluster-api-provider-azure/values.schema.json
+++ b/helm/cluster-api-provider-azure/values.schema.json
@@ -1,0 +1,74 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "crdInstall": {
+            "type": "object",
+            "properties": {
+                "enable": {
+                    "type": "boolean"
+                },
+                "kubectl": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "name": {
+            "type": "string"
+        },
+        "project": {
+            "type": "object",
+            "properties": {
+                "branch": {
+                    "type": "string"
+                },
+                "commit": {
+                    "type": "string"
+                }
+            }
+        },
+        "verticalPodAutoscaler": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "workloadCluster": {
+            "type": "object",
+            "properties": {
+                "ssh": {
+                    "type": "object",
+                    "properties": {
+                        "ssoPublicKey": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.1.3
+  tag: v1.2.1
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

- Update upstream cluster-api-provider-azure version from v1.1.3 to v1.2.1 (highlighted changes TBA)
- Generate values.schema.json.

Highlighted upstream changes:
- [v1.2.0] Added enum values for subnet roles in AzureCluster CRD: `node`, `control-plane` and `bastion`. `node` and `control-plane` enum values were already use before, they are now just also added to OpenAPI schema for the CRD. Vintage is already setting the role to `node`, which is compatible with upstream CRD change.

Upstream release notes:
- [v1.2.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.2.0)
- [v1.2.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.2.1)