### PR TITLE
Upstream update to v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update upstream cluster-api-provider-azure version from v1.2.1 to v1.3.2 (highlights TBA).
+- Update upstream cluster-api-provider-azure version from v1.2.1 to v1.3.2 (see highlighted changes below)
+- [CAPZ v1.3.0] [Add support for Service Principal with Certificate auth using AAD pod identity](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2258). This looks like a breaking change in theory, since `AzureClusterIdentity` `UserAssignedMSI` type is removed, but in practice it is not, because UserAssignedMSI never worked, see [this comment for more details](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2258/files#r859891486). In any case Giant Swarm workload clusters are not be affected, because all of them are using `ServicePrincipal` type.
+
+### cluster-api-provider-azure upstream release notes
+- [v1.3.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.0)
+- [v1.3.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.1)
+- [v1.3.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.2)
 
 ## [1.3.0] - 2022-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update upstream cluster-api-provider-azure version from v1.2.1 to v1.3.2 (highlights TBA).
+
 ## [1.3.0] - 2022-12-16
 
 ### Changed

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -57,7 +57,7 @@
                   type: object
               type: object
             clientID:
-              description: Both User Assigned MSI and SP can use this field.
+              description: ClientID is the service principal client ID. Both User Assigned MSI and SP can use this field.
               type: string
             clientSecret:
               description: ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.
@@ -70,17 +70,17 @@
                   type: string
               type: object
             resourceID:
-              description: User assigned MSI resource id.
+              description: ResourceID is the Azure resource ID for the User Assigned MSI resource. Not currently supported.
               type: string
             tenantID:
-              description: Service principal primary tenant id.
+              description: TenantID is the service principal primary tenant id.
               type: string
             type:
-              description: UserAssignedMSI or Service Principal
+              description: Type is the type of Azure Identity used. ServicePrincipal, ServicePrincipalCertificate, or ManualServicePrincipal.
               enum:
                 - ServicePrincipal
                 - ManualServicePrincipal
-                - UserAssignedMSI
+                - ServicePrincipalCertificate
               type: string
           required:
             - clientID

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -35,6 +35,26 @@
                 type: string
               description: AdditionalTags is an optional set of tags to add to Azure resources managed by the Azure provider, in addition to the ones added by default.
               type: object
+            addonProfiles:
+              description: AddonProfiles are the profiles of managed cluster add-on.
+              items:
+                properties:
+                  config:
+                    additionalProperties:
+                      type: string
+                    description: Config - Key-value pairs for configuring an add-on.
+                    type: object
+                  enabled:
+                    description: Enabled - Whether the add-on is enabled or not.
+                    type: boolean
+                  name:
+                    description: Name- The name of managed cluster add-on.
+                    type: string
+                required:
+                  - enabled
+                  - name
+                type: object
+              type: array
             apiServerAccessProfile:
               description: APIServerAccessProfile is the access profile for AKS API server.
               properties:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -20,6 +20,9 @@
               items:
                 type: string
               type: array
+            enableUltraSSD:
+              description: EnableUltraSSD enables the storage type UltraSSD_LRS for the agent pool.
+              type: boolean
             maxPods:
               description: MaxPods specifies the kubelet --max-pods configuration for the node pool.
               format: int32

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.2.1
+  tag: v1.3.2
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

### Changes

- Update upstream cluster-api-provider-azure version from v1.2.1 to v1.3.2 (see highlighted changes below)

### Highlighted upstream changes that can be relevant for vintage workload clusters

(with specified upstream cluster-api-provider-azure versions)

- `v1.3.0` [Add support for Service Principal with Certificate auth using AAD pod identity](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2258). This looks like a breaking change in theory, since `AzureClusterIdentity` `UserAssignedMSI` type is removed, but in practice it is not, because `UserAssignedMSI` never worked, see [this comment for more details](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2258/files#r859891486). In any case Giant Swarm workload clusters are not be affected, because all of them are using `ServicePrincipal` type (I checked all workload clusters that are deployed at the time of writing on 2022-12-17) and this breaking change is reverted in the next minor release.

### Upstream cluster-api-provider-azure release notes

- [v1.3.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.0)
- [v1.3.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.1)
- [v1.3.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.3.2)
