### PR TITLE
Upstream update to v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Update upstream cluster-api-provider-azure version from v1.3.2 to v1.4.5 (see highlighted changes below)
+
+### Highlighted upstream changes that can be relevant for vintage workload clusters
+
+- N/A
+
+### Highlighted upstream changes
+
+(with specified upstream cluster-api-provider-azure versions)
+
+- `v1.4.0` [Add support for Ultra Disks as Persistent Volumes](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2421)
+- `v1.4.0` [Add support for user-assigned identity as AzureClusterIdentity](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2371)
+- `v1.4.0` [Add ComputeGallery field and add community galleries support](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2277)
+- `v1.4.3` [Add `node-role.kubernetes.io/control-plane` toleration to CAPZ manager deployment](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2640) implemented in [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2644)
+
+### Upstream release notes
+
+- [v1.4.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.0)
+- [v1.4.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.1)
+- [v1.4.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.2)
+- [v1.4.3](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.3)
+- [v1.4.4](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.4)
+- [v1.4.5](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.5)
+
 ## [1.4.0] - 2022-12-19
 
 ### Changed

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -9,7 +9,7 @@ transformers:
   - webhook-prefix.yaml
 
 images:
-  - name: us.gcr.io/k8s-artifacts-prod/cluster-api-azure/cluster-api-azure-controller
+  - name: registry.k8s.io/cluster-api-azure/cluster-api-azure-controller
     newName: "{{.Values.image.registry}}/{{.Values.image.name}}"
     newTag: "{{.Values.image.tag}}"
 

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -53,7 +53,11 @@ spec:
       storage: false
       subresources:
         status: {}
-    - name: v1beta1
+    - additionalPrinterColumns:
+        - jsonPath: .spec.mode
+          name: Mode
+          type: string
+      name: v1beta1
       schema: {}
       served: true
       storage: true

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -74,7 +74,7 @@
                 - calico
               type: string
             nodeResourceGroupName:
-              description: NodeResourceGroupName is the name of the resource group containining cluster IaaS resources. Will be populated to default in webhook.
+              description: NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.
               type: string
             resourceGroupName:
               description: ResourceGroupName is the name of the Azure resource group for this AKS Cluster.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -146,7 +146,7 @@
                 - calico
               type: string
             nodeResourceGroupName:
-              description: NodeResourceGroupName is the name of the resource group containining cluster IaaS resources. Will be populated to default in webhook.
+              description: NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.
               type: string
             resourceGroupName:
               description: ResourceGroupName is the name of the Azure resource group for this AKS Cluster.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -70,15 +70,16 @@
                   type: string
               type: object
             resourceID:
-              description: ResourceID is the Azure resource ID for the User Assigned MSI resource. Not currently supported.
+              description: ResourceID is the Azure resource ID for the User Assigned MSI resource. Only applicable when type is UserAssignedMSI.
               type: string
             tenantID:
               description: TenantID is the service principal primary tenant id.
               type: string
             type:
-              description: Type is the type of Azure Identity used. ServicePrincipal, ServicePrincipalCertificate, or ManualServicePrincipal.
+              description: Type is the type of Azure Identity used. ServicePrincipal, ServicePrincipalCertificate, UserAssignedMSI or ManualServicePrincipal.
               enum:
                 - ServicePrincipal
+                - UserAssignedMSI
                 - ManualServicePrincipal
                 - ServicePrincipalCertificate
               type: string

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -36,6 +36,21 @@
                       properties:
                         dnsName:
                           type: string
+                        ipTags:
+                          items:
+                            description: IPTag contains the IpTag associated with the object.
+                            properties:
+                              tag:
+                                description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                type: string
+                              type:
+                                description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                type: string
+                            required:
+                              - tag
+                              - type
+                            type: object
+                          type: array
                         name:
                           type: string
                       required:
@@ -66,6 +81,21 @@
                               properties:
                                 dnsName:
                                   type: string
+                                ipTags:
+                                  items:
+                                    description: IPTag contains the IpTag associated with the object.
+                                    properties:
+                                      tag:
+                                        description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                        type: string
+                                      type:
+                                        description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                        type: string
+                                    required:
+                                      - tag
+                                      - type
+                                    type: object
+                                  type: array
                                 name:
                                   type: string
                               required:
@@ -300,6 +330,21 @@
                             properties:
                               dnsName:
                                 type: string
+                              ipTags:
+                                items:
+                                  description: IPTag contains the IpTag associated with the object.
+                                  properties:
+                                    tag:
+                                      description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                      type: string
+                                    type:
+                                      description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                      type: string
+                                  required:
+                                    - tag
+                                    - type
+                                  type: object
+                                type: array
                               name:
                                 type: string
                             required:
@@ -346,6 +391,21 @@
                             properties:
                               dnsName:
                                 type: string
+                              ipTags:
+                                items:
+                                  description: IPTag contains the IpTag associated with the object.
+                                  properties:
+                                    tag:
+                                      description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                      type: string
+                                    type:
+                                      description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                      type: string
+                                  required:
+                                    - tag
+                                    - type
+                                  type: object
+                                type: array
                               name:
                                 type: string
                             required:
@@ -392,6 +452,21 @@
                             properties:
                               dnsName:
                                 type: string
+                              ipTags:
+                                items:
+                                  description: IPTag contains the IpTag associated with the object.
+                                  properties:
+                                    tag:
+                                      description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                      type: string
+                                    type:
+                                      description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                      type: string
+                                  required:
+                                    - tag
+                                    - type
+                                  type: object
+                                type: array
                               name:
                                 type: string
                             required:
@@ -451,6 +526,21 @@
                             properties:
                               dnsName:
                                 type: string
+                              ipTags:
+                                items:
+                                  description: IPTag contains the IpTag associated with the object.
+                                  properties:
+                                    tag:
+                                      description: 'Tag specifies the value of the IP tag associated with the public IP. Example: SQL.'
+                                      type: string
+                                    type:
+                                      description: 'Type specifies the IP tag type. Example: FirstPartyUsage.'
+                                      type: string
+                                  required:
+                                    - tag
+                                    - type
+                                  type: object
+                                type: array
                               name:
                                 type: string
                             required:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -137,6 +137,52 @@
                 image:
                   description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
                   properties:
+                    computeGallery:
+                      description: ComputeGallery specifies an image to use from the Azure Compute Gallery
+                      properties:
+                        gallery:
+                          description: Gallery specifies the name of the compute image gallery that contains the image
+                          minLength: 1
+                          type: string
+                        name:
+                          description: Name is the name of the image
+                          minLength: 1
+                          type: string
+                        plan:
+                          description: Plan contains plan information.
+                          properties:
+                            offer:
+                              description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
+                              minLength: 1
+                              type: string
+                            publisher:
+                              description: Publisher is the name of the organization that created the image
+                              minLength: 1
+                              type: string
+                            sku:
+                              description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
+                              minLength: 1
+                              type: string
+                          required:
+                            - offer
+                            - publisher
+                            - sku
+                          type: object
+                        resourceGroup:
+                          description: ResourceGroup specifies the resource group containing the private compute gallery.
+                          type: string
+                        subscriptionID:
+                          description: SubscriptionID is the identifier of the subscription that contains the private compute gallery.
+                          type: string
+                        version:
+                          description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
+                          minLength: 1
+                          type: string
+                      required:
+                        - gallery
+                        - name
+                        - version
+                      type: object
                     id:
                       description: ID specifies an image to use by ID
                       type: string
@@ -170,7 +216,7 @@
                         - version
                       type: object
                     sharedGallery:
-                      description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
+                      description: 'SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.'
                       properties:
                         gallery:
                           description: Gallery specifies the name of the shared image gallery that contains the image
@@ -345,6 +391,52 @@
             image:
               description: Image is the current image used in the AzureMachinePool. When the spec image is nil, this image is populated with the details of the defaulted Azure Marketplace "capi" offer.
               properties:
+                computeGallery:
+                  description: ComputeGallery specifies an image to use from the Azure Compute Gallery
+                  properties:
+                    gallery:
+                      description: Gallery specifies the name of the compute image gallery that contains the image
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name is the name of the image
+                      minLength: 1
+                      type: string
+                    plan:
+                      description: Plan contains plan information.
+                      properties:
+                        offer:
+                          description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
+                          minLength: 1
+                          type: string
+                        publisher:
+                          description: Publisher is the name of the organization that created the image
+                          minLength: 1
+                          type: string
+                        sku:
+                          description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
+                          minLength: 1
+                          type: string
+                      required:
+                        - offer
+                        - publisher
+                        - sku
+                      type: object
+                    resourceGroup:
+                      description: ResourceGroup specifies the resource group containing the private compute gallery.
+                      type: string
+                    subscriptionID:
+                      description: SubscriptionID is the identifier of the subscription that contains the private compute gallery.
+                      type: string
+                    version:
+                      description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
+                      minLength: 1
+                      type: string
+                  required:
+                    - gallery
+                    - name
+                    - version
+                  type: object
                 id:
                   description: ID specifies an image to use by ID
                   type: string
@@ -378,7 +470,7 @@
                     - version
                   type: object
                 sharedGallery:
-                  description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
+                  description: 'SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.'
                   properties:
                     gallery:
                       description: Gallery specifies the name of the shared image gallery that contains the image

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -18,6 +18,13 @@
             acceleratedNetworking:
               description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
               type: boolean
+            additionalCapabilities:
+              description: AdditionalCapabilities specifies additional capabilities enabled or disabled on the virtual machine.
+              properties:
+                ultraSSDEnabled:
+                  description: UltraSSDEnabled enables or disables Azure UltraSSD capability for the virtual machine. Defaults to true if Ultra SSD data disks are specified, otherwise it doesn't set the capability on the VM.
+                  type: boolean
+              type: object
             additionalTags:
               additionalProperties:
                 type: string
@@ -84,6 +91,52 @@
             image:
               description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
               properties:
+                computeGallery:
+                  description: ComputeGallery specifies an image to use from the Azure Compute Gallery
+                  properties:
+                    gallery:
+                      description: Gallery specifies the name of the compute image gallery that contains the image
+                      minLength: 1
+                      type: string
+                    name:
+                      description: Name is the name of the image
+                      minLength: 1
+                      type: string
+                    plan:
+                      description: Plan contains plan information.
+                      properties:
+                        offer:
+                          description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
+                          minLength: 1
+                          type: string
+                        publisher:
+                          description: Publisher is the name of the organization that created the image
+                          minLength: 1
+                          type: string
+                        sku:
+                          description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
+                          minLength: 1
+                          type: string
+                      required:
+                        - offer
+                        - publisher
+                        - sku
+                      type: object
+                    resourceGroup:
+                      description: ResourceGroup specifies the resource group containing the private compute gallery.
+                      type: string
+                    subscriptionID:
+                      description: SubscriptionID is the identifier of the subscription that contains the private compute gallery.
+                      type: string
+                    version:
+                      description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
+                      minLength: 1
+                      type: string
+                  required:
+                    - gallery
+                    - name
+                    - version
+                  type: object
                 id:
                   description: ID specifies an image to use by ID
                   type: string
@@ -117,7 +170,7 @@
                     - version
                   type: object
                 sharedGallery:
-                  description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
+                  description: 'SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.'
                   properties:
                     gallery:
                       description: Gallery specifies the name of the shared image gallery that contains the image

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -38,6 +38,13 @@
                     acceleratedNetworking:
                       description: AcceleratedNetworking enables or disables Azure accelerated networking. If omitted, it will be set based on whether the requested VMSize supports accelerated networking. If AcceleratedNetworking is set to true with a VMSize that does not support it, Azure will return an error.
                       type: boolean
+                    additionalCapabilities:
+                      description: AdditionalCapabilities specifies additional capabilities enabled or disabled on the virtual machine.
+                      properties:
+                        ultraSSDEnabled:
+                          description: UltraSSDEnabled enables or disables Azure UltraSSD capability for the virtual machine. Defaults to true if Ultra SSD data disks are specified, otherwise it doesn't set the capability on the VM.
+                          type: boolean
+                      type: object
                     additionalTags:
                       additionalProperties:
                         type: string
@@ -104,6 +111,52 @@
                     image:
                       description: Image is used to provide details of an image to use during VM creation. If image details are omitted the image will default the Azure Marketplace "capi" offer, which is based on Ubuntu.
                       properties:
+                        computeGallery:
+                          description: ComputeGallery specifies an image to use from the Azure Compute Gallery
+                          properties:
+                            gallery:
+                              description: Gallery specifies the name of the compute image gallery that contains the image
+                              minLength: 1
+                              type: string
+                            name:
+                              description: Name is the name of the image
+                              minLength: 1
+                              type: string
+                            plan:
+                              description: Plan contains plan information.
+                              properties:
+                                offer:
+                                  description: Offer specifies the name of a group of related images created by the publisher. For example, UbuntuServer, WindowsServer
+                                  minLength: 1
+                                  type: string
+                                publisher:
+                                  description: Publisher is the name of the organization that created the image
+                                  minLength: 1
+                                  type: string
+                                sku:
+                                  description: SKU specifies an instance of an offer, such as a major release of a distribution. For example, 18.04-LTS, 2019-Datacenter
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - offer
+                                - publisher
+                                - sku
+                              type: object
+                            resourceGroup:
+                              description: ResourceGroup specifies the resource group containing the private compute gallery.
+                              type: string
+                            subscriptionID:
+                              description: SubscriptionID is the identifier of the subscription that contains the private compute gallery.
+                              type: string
+                            version:
+                              description: Version specifies the version of the marketplace image. The allowed formats are Major.Minor.Build or 'latest'. Major, Minor, and Build are decimal numbers. Specify 'latest' to use the latest version of an image available at deploy time. Even if you use 'latest', the VM image will not automatically update after deploy time even if a new version becomes available.
+                              minLength: 1
+                              type: string
+                          required:
+                            - gallery
+                            - name
+                            - version
+                          type: object
                         id:
                           description: ID specifies an image to use by ID
                           type: string
@@ -137,7 +190,7 @@
                             - version
                           type: object
                         sharedGallery:
-                          description: SharedGallery specifies an image to use from an Azure Shared Image Gallery
+                          description: 'SharedGallery specifies an image to use from an Azure Shared Image Gallery Deprecated: use ComputeGallery instead.'
                           properties:
                             gallery:
                               description: Gallery specifies the name of the shared image gallery that contains the image

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -166,7 +166,7 @@
                 - calico
               type: string
             nodeResourceGroupName:
-              description: NodeResourceGroupName is the name of the resource group containining cluster IaaS resources. Will be populated to default in webhook.
+              description: NodeResourceGroupName is the name of the resource group containing cluster IaaS resources. Will be populated to default in webhook.
               type: string
             resourceGroupName:
               description: ResourceGroupName is the name of the Azure resource group for this AKS Cluster.

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -52,6 +52,12 @@
                 - Ephemeral
                 - Managed
               type: string
+            osType:
+              description: 'OSType specifies the virtual machine operating system. Default to Linux. Possible values include: ''Linux'', ''Windows'''
+              enum:
+                - Linux
+                - Windows
+              type: string
             providerIDList:
               description: ProviderIDList is the unique identifier as specified by the cloud provider.
               items:

--- a/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
+++ b/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/default-logs-container: manager
+        kubectl.kubernetes.io/default-container: manager
       labels:
         aadpodidbinding: capz-controller-aadpodidentity-selector
         cluster.x-k8s.io/provider: infrastructure-azure
@@ -99,6 +99,11 @@ spec:
           readOnly: true
       serviceAccountName: capz-manager
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
       volumes:
       - name: cert
         secret:

--- a/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
@@ -78,6 +78,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - cluster.x-k8s.io

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.3.2
+  tag: v1.4.5
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

This PR is currently on top of `upstream-update-v1.3.2` branch.

TODO:
- [x] Update changelog after merging https://github.com/giantswarm/cluster-api-provider-azure-app/pull/76
- [x] Rebase on `main` after merging https://github.com/giantswarm/cluster-api-provider-azure-app/pull/76

### Changes

- Update upstream cluster-api-provider-azure version from v1.3.2 to v1.4.5 (see highlighted changes below)

### Highlighted upstream changes that can be relevant for vintage workload clusters

- N/A

### Highlighted upstream changes

(with specified upstream cluster-api-provider-azure versions)

- `v1.4.0` [Add support for Ultra Disks as Persistent Volumes](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2421)
- `v1.4.0` [Add support for user-assigned identity as AzureClusterIdentity](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2371)
- `v1.4.0` [Add ComputeGallery field and add community galleries support](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2277)
- `v1.4.3` [Add `node-role.kubernetes.io/control-plane` toleration to CAPZ manager deployment](https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/2640) implemented in [this PR](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2644)

### Upstream release notes

- [v1.4.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.0)
- [v1.4.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.1)
- [v1.4.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.2)
- [v1.4.3](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.3)
- [v1.4.4](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.4)
- [v1.4.5](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.4.5)