### PR TITLE
Upstream update to v1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 (with specified upstream cluster-api-provider-azure versions)
 
-- `v1.5.3` `controller-gen.kubebuilder.io/version` bump from v0.8.0 to v0.9.2.
+- `v1.5.3` `controller-gen.kubebuilder.io/version` bump from v0.8.0 to v0.9.2. This caused removal of `Status` field and addition of `x-kubernetes-map-type` in CRDs. 
 
 ### Upstream release notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Update upstream cluster-api-provider-azure version from v1.4.5 to v1.5.4 (see highlighted changes below)
+
+### Highlighted upstream changes that can be relevant for vintage workload clusters
+
+- N/A
+
+### Highlighted upstream changes
+
+(with specified upstream cluster-api-provider-azure versions)
+
+- `v1.5.3` `controller-gen.kubebuilder.io/version` bump from v0.8.0 to v0.9.2.
+
+### Upstream release notes
+
+- [v1.5.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.0)
+- [v1.5.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.1)
+- [v1.5.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.2)
+- [v1.5.3](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.3)
+- [v1.5.4](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.4)
+
 ## [1.5.0] - 2022-12-20
 
 ### Changes

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -57,9 +57,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -146,9 +146,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -43,9 +43,3 @@ spec:
       schema: {}
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepoolmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -99,9 +99,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -158,9 +158,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -150,9 +150,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -51,9 +51,3 @@ spec:
       schema: {}
       served: true
       storage: true
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -59,9 +59,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -59,9 +59,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -63,9 +63,3 @@ spec:
       storage: true
       subresources:
         status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -27,12 +27,13 @@
               description: ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.
               properties:
                 name:
-                  description: Name is unique within a namespace to reference a secret resource.
+                  description: name is unique within a namespace to reference a secret resource.
                   type: string
                 namespace:
-                  description: Namespace defines the space within which the secret name must be unique.
+                  description: namespace defines the space within which the secret name must be unique.
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             resourceID:
               description: User assigned MSI resource id.
               type: string

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha3/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -59,6 +59,7 @@
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             location:
               type: string
             networkSpec:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -55,6 +55,7 @@
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
               type: object
             clientID:
               description: Both User Assigned MSI and SP can use this field.
@@ -63,12 +64,13 @@
               description: ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.
               properties:
                 name:
-                  description: Name is unique within a namespace to reference a secret resource.
+                  description: name is unique within a namespace to reference a secret resource.
                   type: string
                 namespace:
-                  description: Namespace defines the space within which the secret name must be unique.
+                  description: namespace defines the space within which the secret name must be unique.
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             resourceID:
               description: User assigned MSI resource id.
               type: string

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1alpha4/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -262,6 +262,7 @@
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             location:
               type: string
             networkSpec:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusteridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -55,6 +55,7 @@
                       description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                       type: object
                   type: object
+                  x-kubernetes-map-type: atomic
               type: object
             clientID:
               description: ClientID is the service principal client ID. Both User Assigned MSI and SP can use this field.
@@ -63,12 +64,13 @@
               description: ClientSecret is a secret reference which should contain either a Service Principal password or certificate secret.
               properties:
                 name:
-                  description: Name is unique within a namespace to reference a secret resource.
+                  description: name is unique within a namespace to reference a secret resource.
                   type: string
                 namespace:
-                  description: Namespace defines the space within which the secret name must be unique.
+                  description: namespace defines the space within which the secret name must be unique.
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             resourceID:
               description: ResourceID is the Azure resource ID for the User Assigned MSI resource. Only applicable when type is UserAssignedMSI.
               type: string

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -180,6 +180,9 @@
                                   - protocol
                                 type: object
                               type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
                             tags:
                               additionalProperties:
                                 type: string
@@ -308,6 +311,7 @@
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
               type: object
+              x-kubernetes-map-type: atomic
             location:
               type: string
             networkSpec:
@@ -625,6 +629,9 @@
                                 - protocol
                               type: object
                             type: array
+                            x-kubernetes-list-map-keys:
+                              - name
+                            x-kubernetes-list-type: map
                           tags:
                             additionalProperties:
                               type: string
@@ -638,6 +645,9 @@
                       - role
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - name
+                  x-kubernetes-list-type: map
                 vnet:
                   description: Vnet is the configuration for the Azure virtual network.
                   properties:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -19,6 +19,7 @@
               description: AzureClusterTemplateResource describes the data needed to create an AzureCluster from a template.
               properties:
                 spec:
+                  description: AzureClusterTemplateResourceSpec specifies an Azure cluster template resource.
                   properties:
                     additionalTags:
                       additionalProperties:
@@ -32,14 +33,19 @@
                       description: BastionSpec encapsulates all things related to the Bastions in the cluster.
                       properties:
                         azureBastion:
+                          description: AzureBastionTemplateSpec specifies a template for an Azure Bastion host.
                           properties:
                             subnet:
+                              description: SubnetTemplateSpec specifies a template for a subnet.
                               properties:
                                 cidrBlocks:
                                   description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
                                   items:
                                     type: string
                                   type: array
+                                name:
+                                  description: Name defines a name for the subnet resource.
+                                  type: string
                                 natGateway:
                                   description: NatGateway associated with this subnet.
                                   properties:
@@ -106,6 +112,9 @@
                                           - protocol
                                         type: object
                                       type: array
+                                      x-kubernetes-list-map-keys:
+                                        - name
+                                      x-kubernetes-list-type: map
                                     tags:
                                       additionalProperties:
                                         type: string
@@ -113,6 +122,7 @@
                                       type: object
                                   type: object
                               required:
+                                - name
                                 - role
                               type: object
                           type: object
@@ -217,6 +227,7 @@
                           description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                           type: string
                       type: object
+                      x-kubernetes-map-type: atomic
                     location:
                       type: string
                     networkSpec:
@@ -270,12 +281,16 @@
                         subnets:
                           description: Subnets is the configuration for the control-plane subnet and the node subnet.
                           items:
+                            description: SubnetTemplateSpec specifies a template for a subnet.
                             properties:
                               cidrBlocks:
                                 description: CIDRBlocks defines the subnet's address space, specified as one or more address prefixes in CIDR notation.
                                 items:
                                   type: string
                                 type: array
+                              name:
+                                description: Name defines a name for the subnet resource.
+                                type: string
                               natGateway:
                                 description: NatGateway associated with this subnet.
                                 properties:
@@ -342,6 +357,9 @@
                                         - protocol
                                       type: object
                                     type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
                                   tags:
                                     additionalProperties:
                                       type: string
@@ -349,9 +367,13 @@
                                     type: object
                                 type: object
                             required:
+                              - name
                               - role
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
                         vnet:
                           description: Vnet is the configuration for the Azure virtual network.
                           properties:
@@ -363,9 +385,13 @@
                             peerings:
                               description: Peerings defines a list of peerings of the newly created virtual network with existing virtual networks.
                               items:
+                                description: VnetPeeringClassSpec specifies a virtual network peering class.
                                 properties:
                                   remoteVnetName:
                                     description: RemoteVnetName defines name of the remote virtual network.
+                                    type: string
+                                  resourceGroup:
+                                    description: ResourceGroup is the resource group name of the remote virtual network.
                                     type: string
                                 required:
                                   - remoteVnetName

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -74,6 +74,11 @@
                   - nameSuffix
                 type: object
               type: array
+            dnsServers:
+              description: DNSServers adds a list of DNS Server IP addresses to the VM NICs.
+              items:
+                type: string
+              type: array
             enableIPForwarding:
               description: EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.
               type: boolean

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -94,6 +94,11 @@
                           - nameSuffix
                         type: object
                       type: array
+                    dnsServers:
+                      description: DNSServers adds a list of DNS Server IP addresses to the VM NICs.
+                      items:
+                        type: string
+                      type: array
                     enableIPForwarding:
                       description: EnableIPForwarding enables IP Forwarding in Azure which is required for some CNI's to send traffic from a pods on one machine to another. This is required for IpV6 with Calico in combination with User Defined Routes (set by the Azure Cloud Controller manager). Default is false for disabled.
                       type: boolean

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -38,17 +38,18 @@
             addonProfiles:
               description: AddonProfiles are the profiles of managed cluster add-on.
               items:
+                description: AddonProfile represents a managed cluster add-on.
                 properties:
                   config:
                     additionalProperties:
                       type: string
-                    description: Config - Key-value pairs for configuring an add-on.
+                    description: Config - Key-value pairs for configuring the add-on.
                     type: object
                   enabled:
                     description: Enabled - Whether the add-on is enabled or not.
                     type: boolean
                   name:
-                    description: Name- The name of managed cluster add-on.
+                    description: Name - The name of the managed cluster add-on.
                     type: string
                 required:
                   - enabled

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -20,6 +20,9 @@
               items:
                 type: string
               type: array
+            enableNodePublicIP:
+              description: EnableNodePublicIP controls whether or not nodes in the pool each have a public IP address.
+              type: boolean
             enableUltraSSD:
               description: EnableUltraSSD enables the storage type UltraSSD_LRS for the agent pool.
               type: boolean
@@ -79,6 +82,7 @@
             taints:
               description: Taints specifies the taints for nodes present in this agent pool.
               items:
+                description: Taint represents a Kubernetes taint.
                 properties:
                   effect:
                     description: Effect specifies the effect for the taint

--- a/helm/cluster-api-provider-azure/templates/_helpers_gen.tpl
+++ b/helm/cluster-api-provider-azure/templates/_helpers_gen.tpl
@@ -3,5 +3,5 @@ This file contains generated annotation values. All changes will be overwritten 
 */}}
 
 {{- define "annotations.kubebuilder_version" -}}
-v0.8.0
+v0.9.2
 {{- end -}}

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.4.5
+  tag: v1.5.4
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

### Changes

- Update upstream cluster-api-provider-azure version from v1.4.5 to v1.5.4 (see highlighted changes below)

### Highlighted upstream changes that can be relevant for vintage workload clusters

- N/A

### Highlighted upstream changes

(with specified upstream cluster-api-provider-azure versions)

- `v1.5.3` `controller-gen.kubebuilder.io/version` bump from v0.8.0 to v0.9.2. This caused removal of `Status` field and addition of `x-kubernetes-map-type` in CRDs. 

### Upstream release notes

- [v1.5.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.0)
- [v1.5.1](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.1)
- [v1.5.2](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.2)
- [v1.5.3](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.3)
- [v1.5.4](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.5.4)