### PR TITLE
Upstream update from v1.5.4 to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Update upstream cluster-api-provider-azure version from v1.5.4 to v1.6.0 (see highlighted changes below)
+
+### Highlighted upstream changes that can be relevant for vintage workload clusters
+
+- `v1.6.0` [Add evictionPolicy field for spot VMs](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2689). Vintage workload clusters support node pools that are using spot instances with Azure's default `Deallocate` eviction policy. Changing eviction policy is not possible for vintage workload clusters. 
+
+### Highlighted upstream changes
+
+(with specified upstream cluster-api-provider-azure versions)
+
+- `v1.6.0` [Add support for custom vm extensions](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2631)
+- `v1.6.0` [Add support for adding Virtual Network Service Endpoints to subnets created/managed by CAPZ](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2635)
+
+### Upstream release notes
+
+- [v1.6.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.6.0)
+
 ## [1.6.0] - 2022-12-20
 
 ### Changes

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -191,6 +191,25 @@
                           required:
                             - name
                           type: object
+                        serviceEndpoints:
+                          description: ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
+                          items:
+                            description: ServiceEndpointSpec configures an Azure Service Endpoint.
+                            properties:
+                              locations:
+                                items:
+                                  type: string
+                                type: array
+                              service:
+                                type: string
+                            required:
+                              - locations
+                              - service
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - service
+                          x-kubernetes-list-type: map
                       required:
                         - name
                         - role
@@ -640,6 +659,25 @@
                         required:
                           - name
                         type: object
+                      serviceEndpoints:
+                        description: ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
+                        items:
+                          description: ServiceEndpointSpec configures an Azure Service Endpoint.
+                          properties:
+                            locations:
+                              items:
+                                type: string
+                              type: array
+                            service:
+                              type: string
+                          required:
+                            - locations
+                            - service
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                          - service
+                        x-kubernetes-list-type: map
                     required:
                       - name
                       - role

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -121,6 +121,25 @@
                                       description: Tags defines a map of tags.
                                       type: object
                                   type: object
+                                serviceEndpoints:
+                                  description: ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
+                                  items:
+                                    description: ServiceEndpointSpec configures an Azure Service Endpoint.
+                                    properties:
+                                      locations:
+                                        items:
+                                          type: string
+                                        type: array
+                                      service:
+                                        type: string
+                                    required:
+                                      - locations
+                                      - service
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - service
+                                  x-kubernetes-list-type: map
                               required:
                                 - name
                                 - role
@@ -366,6 +385,25 @@
                                     description: Tags defines a map of tags.
                                     type: object
                                 type: object
+                              serviceEndpoints:
+                                description: ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
+                                items:
+                                  description: ServiceEndpointSpec configures an Azure Service Endpoint.
+                                  properties:
+                                    locations:
+                                      items:
+                                        type: string
+                                      type: array
+                                    service:
+                                      type: string
+                                  required:
+                                    - locations
+                                    - service
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - service
+                                x-kubernetes-list-type: map
                             required:
                               - name
                               - role

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -308,6 +308,12 @@
                 spotVMOptions:
                   description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
                   properties:
+                    evictionPolicy:
+                      description: EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.
+                      enum:
+                        - Deallocate
+                        - Delete
+                      type: string
                     maxPrice:
                       anyOf:
                         - type: integer
@@ -325,6 +331,36 @@
                 terminateNotificationTimeout:
                   description: TerminateNotificationTimeout enables or disables VMSS scheduled events termination notification with specified timeout allowed values are between 5 and 15 (mins)
                   type: integer
+                vmExtensions:
+                  description: VMExtensions specifies a list of extensions to be added to the scale set.
+                  items:
+                    description: VMExtension specifies the parameters for a custom VM extension.
+                    properties:
+                      name:
+                        description: Name is the name of the extension.
+                        type: string
+                      protectedSettings:
+                        additionalProperties:
+                          type: string
+                        description: ProtectedSettings is a JSON formatted protected settings for the extension.
+                        type: object
+                      publisher:
+                        description: Publisher is the name of the extension handler publisher.
+                        type: string
+                      settings:
+                        additionalProperties:
+                          type: string
+                        description: Settings is a JSON formatted public settings for the extension.
+                        type: object
+                      version:
+                        description: Version specifies the version of the script handler.
+                        type: string
+                    required:
+                      - name
+                      - publisher
+                      - version
+                    type: object
+                  type: array
                 vmSize:
                   description: VMSize is the size of the Virtual Machine to build. See https://docs.microsoft.com/en-us/rest/api/compute/virtualmachines/createorupdate#virtualmachinesizetypes
                   type: string

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachines.infrastructure.cluster.x-k8s.io.yaml
@@ -273,6 +273,12 @@
             spotVMOptions:
               description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
               properties:
+                evictionPolicy:
+                  description: EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.
+                  enum:
+                    - Deallocate
+                    - Delete
+                  type: string
                 maxPrice:
                   anyOf:
                     - type: integer
@@ -296,6 +302,36 @@
                     type: string
                 required:
                   - providerID
+                type: object
+              type: array
+            vmExtensions:
+              description: VMExtensions specifies a list of extensions to be added to the virtual machine.
+              items:
+                description: VMExtension specifies the parameters for a custom VM extension.
+                properties:
+                  name:
+                    description: Name is the name of the extension.
+                    type: string
+                  protectedSettings:
+                    additionalProperties:
+                      type: string
+                    description: ProtectedSettings is a JSON formatted protected settings for the extension.
+                    type: object
+                  publisher:
+                    description: Publisher is the name of the extension handler publisher.
+                    type: string
+                  settings:
+                    additionalProperties:
+                      type: string
+                    description: Settings is a JSON formatted public settings for the extension.
+                    type: object
+                  version:
+                    description: Version specifies the version of the script handler.
+                    type: string
+                required:
+                  - name
+                  - publisher
+                  - version
                 type: object
               type: array
             vmSize:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -293,6 +293,12 @@
                     spotVMOptions:
                       description: SpotVMOptions allows the ability to specify the Machine should use a Spot VM
                       properties:
+                        evictionPolicy:
+                          description: EvictionPolicy defines the behavior of the virtual machine when it is evicted. It can be either Delete or Deallocate.
+                          enum:
+                            - Deallocate
+                            - Delete
+                          type: string
                         maxPrice:
                           anyOf:
                             - type: integer
@@ -316,6 +322,36 @@
                             type: string
                         required:
                           - providerID
+                        type: object
+                      type: array
+                    vmExtensions:
+                      description: VMExtensions specifies a list of extensions to be added to the virtual machine.
+                      items:
+                        description: VMExtension specifies the parameters for a custom VM extension.
+                        properties:
+                          name:
+                            description: Name is the name of the extension.
+                            type: string
+                          protectedSettings:
+                            additionalProperties:
+                              type: string
+                            description: ProtectedSettings is a JSON formatted protected settings for the extension.
+                            type: object
+                          publisher:
+                            description: Publisher is the name of the extension handler publisher.
+                            type: string
+                          settings:
+                            additionalProperties:
+                              type: string
+                            description: Settings is a JSON formatted public settings for the extension.
+                            type: object
+                          version:
+                            description: Version specifies the version of the script handler.
+                            type: string
+                        required:
+                          - name
+                          - publisher
+                          - version
                         type: object
                       type: array
                     vmSize:

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -201,6 +201,9 @@
                   type: string
                 name:
                   type: string
+                resourceGroup:
+                  description: ResourceGroup is the name of the Azure resource group for the VNet and Subnet.
+                  type: string
                 subnet:
                   description: ManagedControlPlaneSubnet describes a subnet for an AKS cluster.
                   properties:
@@ -208,6 +211,25 @@
                       type: string
                     name:
                       type: string
+                    serviceEndpoints:
+                      description: ServiceEndpoints is a slice of Virtual Network service endpoints to enable for the subnets.
+                      items:
+                        description: ServiceEndpointSpec configures an Azure Service Endpoint.
+                        properties:
+                          locations:
+                            items:
+                              type: string
+                            type: array
+                          service:
+                            type: string
+                        required:
+                          - locations
+                          - service
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                        - service
+                      x-kubernetes-list-type: map
                   required:
                     - cidrBlock
                     - name

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -44,6 +44,9 @@
                 type: string
               description: Node labels - labels for all of the nodes present in node pool
               type: object
+            nodePublicIPPrefixID:
+              description: NodePublicIPPrefixID specifies the public IP prefix resource ID which VM nodes should use IPs from.
+              type: string
             osDiskSizeGB:
               description: OSDiskSizeGB is the disk size for every machine in this agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.
               format: int32
@@ -66,6 +69,12 @@
               items:
                 type: string
               type: array
+            scaleSetPriority:
+              description: 'ScaleSetPriority specifies the ScaleSetPriority value. Default to Regular. Possible values include: ''Regular'', ''Spot'''
+              enum:
+                - Regular
+                - Spot
+              type: string
             scaling:
               description: Scaling specifies the autoscaling parameters for the node pool.
               properties:

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.5.4
+  tag: v1.6.0
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/24551

### Changes

- Update upstream cluster-api-provider-azure version from v1.5.4 to v1.6.0 (see highlighted changes below)

### Highlighted upstream changes that can be relevant for vintage workload clusters

- `v1.6.0` [Add evictionPolicy field for spot VMs](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2689). Vintage workload clusters support node pools that are using spot instances with Azure's default `Deallocate` eviction policy. Changing eviction policy is not possible for vintage workload clusters. 

### Highlighted upstream changes

(with specified upstream cluster-api-provider-azure versions)

- `v1.6.0` [Add support for custom vm extensions](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2631)
- `v1.6.0` [Add support for adding Virtual Network Service Endpoints to subnets created/managed by CAPZ](https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/2635)

### Upstream release notes

- [v1.6.0](https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v1.6.0)