### PR TITLE
Don't use watch filter on CAPI MCs

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -8,6 +8,7 @@ generate:
 	./hack/move-generated-crds.sh
 	./hack/generate-crd-version-patches.sh
 	./hack/generate-helm-helpers.sh
+	./hack/generate-helm-conditions.sh
 
 .PHONY: verify
 verify: generate

--- a/config/helm/deployment-args.yaml
+++ b/config/helm/deployment-args.yaml
@@ -11,5 +11,5 @@ spec:
           args:
             - --metrics-bind-addr=0.0.0.0:8080
             - --feature-gates=MachinePool=true,AKS=false
-            - --watch-filter=capi
+            - --watch-filter="{{- include "deployment.args.watchfiltervalue" . -}}"
             - --v=0

--- a/hack/generate-helm-conditions.sh
+++ b/hack/generate-helm-conditions.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script prepends helm if statement to every Helm template, which checks
+# if .Values.provider.flavor is equal to "capi".
+
+# Directories
+ROOT_DIR="./$(dirname "$0")/.."
+ROOT_DIR="$(realpath "$ROOT_DIR")"
+HELM_DIR="$ROOT_DIR/helm/cluster-api-provider-azure"
+
+for template_file in "$HELM_DIR"/templates/admissionregistration.k8s.io_v1_*webhookconfiguration_*.yaml; do
+    temp_template_file="$template_file.tmp"
+    echo '{{ if eq .Values.provider.flavor "capi" }}' | cat - "$template_file" > "$temp_template_file" && mv "$temp_template_file" "$template_file"
+    echo '{{ end }}' >> "$template_file"
+done

--- a/helm/cluster-api-provider-azure/templates/_helpers.tpl
+++ b/helm/cluster-api-provider-azure/templates/_helpers.tpl
@@ -55,3 +55,15 @@ app.kubernetes.io/instance: "{{ template "name" . }}"
 {{- define "capz.CRDInstallSelector" -}}
 {{- printf "%s" "crd-install-hook" -}}
 {{- end -}}
+
+{{/*
+Watch filter value:
+  CAPI MCs: empty (controllers are reconciling all CRs on CAPI MCs)
+  Vintage MCs: capi (controllers are watching only labeled CRs and are not reconciling vintage WC CRs)
+*/}}
+{{- define "deployment.args.watchfiltervalue" -}}
+{{- if eq .Values.provider.flavor "capi" -}}
+{{- else -}}
+capi
+{{- end -}}
+{{- end -}}

--- a/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_zzz-capz-mutating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_zzz-capz-mutating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.provider.flavor "capi" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -187,3 +188,4 @@ webhooks:
     resources:
     - azuremanagedmachinepools
   sideEffects: None
+{{ end }}

--- a/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.provider.flavor "capi" }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -234,3 +235,4 @@ webhooks:
     resources:
     - azuremanagedmachinepools
   sideEffects: None
+{{ end }}

--- a/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
+++ b/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
@@ -33,7 +33,7 @@ spec:
       - args:
         - --metrics-bind-addr=0.0.0.0:8080
         - --feature-gates=MachinePool=true,AKS=false
-        - --watch-filter=capi
+        - --watch-filter="{{- include "deployment.args.watchfiltervalue" . -}}"
         - --v=0
         env:
         - name: AZURE_SUBSCRIPTION_ID

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -8,6 +8,9 @@ project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
 
+provider:
+  flavor: vintage
+
 crdInstall:
   enable: true
   kubectl:


### PR DESCRIPTION
- Deploy admission webhooks only to CAPZ MCs (we are not using them in vintage)
- Set watch filter deployment argument only in vintage MCs
  - We need CAPZ controllers in vintage MCs for CR conversion
  - CAPZ controllers that are running in vintage MCs will reconcile only CRs that are labeled with watch filter label (we don't label any now)
  - CAPZ controllers that are running in CAPI MCs will reconcile all CRs (watch filter label is not required)