### PR TITLE
Revert the `creationTimestamp` null since it breaks installing the CRDs in a brand new cluster

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -3,7 +3,6 @@ generate:
 	./hack/generate-kustomize-patches.sh
 	@rm -rf helm/cluster-api-provider-azure/templates/*.yaml
 	@cp helm/cluster-api-provider-azure/files/copy/* helm/cluster-api-provider-azure/templates/
-	@kustomize version
 	@kustomize build config/helm -o helm/cluster-api-provider-azure/templates
 	./hack/move-generated-crds.sh
 	./hack/generate-crd-version-patches.sh

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -3,6 +3,7 @@ generate:
 	./hack/generate-kustomize-patches.sh
 	@rm -rf helm/cluster-api-provider-azure/templates/*.yaml
 	@cp helm/cluster-api-provider-azure/files/copy/* helm/cluster-api-provider-azure/templates/
+	@kustomize version
 	@kustomize build config/helm -o helm/cluster-api-provider-azure/templates
 	./hack/move-generated-crds.sh
 	./hack/generate-crd-version-patches.sh

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -64,3 +64,9 @@ patches:
     kind: DaemonSet
     name: capz-nmi
   path: daemonset-nmi-args.yaml
+- target:
+    kind: CustomResourceDefinition
+    name: (azuremanagedmachinepools|azuremanagedcontrolplanes|azuremanagedclusters).infrastructure.cluster.x-k8s.io
+  patch: |-
+    - op: remove
+      path: /metadata/creationTimestamp

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -64,10 +64,3 @@ patches:
     kind: DaemonSet
     name: capz-nmi
   path: daemonset-nmi-args.yaml
-- target:
-    kind: CustomResourceDefinition
-    name: (azuremanagedmachinepools|azuremanagedcontrolplanes|azuremanagedclusters).infrastructure.cluster.x-k8s.io
-  patch: |-
-    - op: add
-      path: /metadata/creationTimestamp
-      value: "null"

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
     controller-gen.kubebuilder.io/version: '{{- include "annotations.kubebuilder_version" . -}}'
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedcontrolplanes.infrastructure.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
     controller-gen.kubebuilder.io/version: '{{- include "annotations.kubebuilder_version" . -}}'
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'

--- a/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/bases/azuremanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/capz-serving-cert'
     controller-gen.kubebuilder.io/version: '{{- include "annotations.kubebuilder_version" . -}}'
-  creationTimestamp: "null"
   labels:
     app.giantswarm.io/branch: '{{ .Values.project.branch }}'
     app.giantswarm.io/commit: '{{ .Values.project.commit }}'


### PR DESCRIPTION
fixes https://github.com/giantswarm/roadmap/issues/2171

```
cluster-api-provider-azure-crd-install-hmzbl kubectl unable to decode "/files": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
cluster-api-provider-azure-crd-install-hmzbl kubectl unable to decode "/files": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
cluster-api-provider-azure-crd-install-hmzbl kubectl unable to decode "/files": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```
