### PR TITLE
Update CAPZ go use version from the fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update upstream CAPZ to use version from the fork to get gateway transit feature.
+
 ## [1.8.1] - 2023-03-09
 
 ### Changes

--- a/hack/generate-helm-helpers.sh
+++ b/hack/generate-helm-helpers.sh
@@ -18,7 +18,7 @@ KUSTOMIZE_INPUT_DIR="$ROOT_DIR/config/helm/input"
 
 # Download upstream manifests
 helm_values="$HELM_DIR/values.yaml"
-org="kubernetes-sigs"
+org="giantswarm"
 repo="cluster-api-provider-azure"
 version="$(yq e '.image.tag' "$helm_values")"
 release_asset_filename="infrastructure-components.yaml"

--- a/hack/generate-kustomize-patches.sh
+++ b/hack/generate-kustomize-patches.sh
@@ -20,7 +20,7 @@ KUSTOMIZE_INPUT_DIR="$ROOT_DIR/config/helm/input"
 
 # Download upstream manifests
 helm_values="$HELM_DIR/values.yaml"
-org="kubernetes-sigs"
+org="giantswarm"
 repo="cluster-api-provider-azure"
 version="$(yq e '.image.tag' "$helm_values")"
 release_asset_filename="infrastructure-components.yaml"

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -864,12 +864,34 @@
                       items:
                         description: VnetPeeringSpec specifies an existing remote virtual network to peer with the AzureCluster's virtual network.
                         properties:
+                          forwardPeeringProperties:
+                            properties:
+                              allowForwardedTraffic:
+                                type: boolean
+                              allowGatewayTransit:
+                                type: boolean
+                              allowVirtualNetworkAccess:
+                                type: boolean
+                              useRemoteGateways:
+                                type: boolean
+                            type: object
                           remoteVnetName:
                             description: RemoteVnetName defines name of the remote virtual network.
                             type: string
                           resourceGroup:
                             description: ResourceGroup is the resource group name of the remote virtual network.
                             type: string
+                          reversePeeringProperties:
+                            properties:
+                              allowForwardedTraffic:
+                                type: boolean
+                              allowGatewayTransit:
+                                type: boolean
+                              allowVirtualNetworkAccess:
+                                type: boolean
+                              useRemoteGateways:
+                                type: boolean
+                            type: object
                         required:
                           - remoteVnetName
                         type: object

--- a/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-azure/files/infrastructure/patches/versions/v1beta1/azureclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -552,12 +552,34 @@
                               items:
                                 description: VnetPeeringClassSpec specifies a virtual network peering class.
                                 properties:
+                                  forwardPeeringProperties:
+                                    properties:
+                                      allowForwardedTraffic:
+                                        type: boolean
+                                      allowGatewayTransit:
+                                        type: boolean
+                                      allowVirtualNetworkAccess:
+                                        type: boolean
+                                      useRemoteGateways:
+                                        type: boolean
+                                    type: object
                                   remoteVnetName:
                                     description: RemoteVnetName defines name of the remote virtual network.
                                     type: string
                                   resourceGroup:
                                     description: ResourceGroup is the resource group name of the remote virtual network.
                                     type: string
+                                  reversePeeringProperties:
+                                    properties:
+                                      allowForwardedTraffic:
+                                        type: boolean
+                                      allowGatewayTransit:
+                                        type: boolean
+                                      allowVirtualNetworkAccess:
+                                        type: boolean
+                                      useRemoteGateways:
+                                        type: boolean
+                                    type: object
                                 required:
                                   - remoteVnetName
                                 type: object

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.2
+  tag: v1.9.0-gs.alpha.3
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.8.0
+  tag: v1.9.0-gs.alpha.2
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.3
+  tag: v1.9.0-gs.alpha.4
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2041

This PR changes cluster-api-provider-azure-app to use an alpha version from our CAPZ fork, so we can release an alpha version of cluster-api-provider-azure-app wit gateway transit feature.

We will our fork here in the app until CAPZ get a new release which includes those changes.