### PR TITLE
Update capz version to v1.9.0 gs.alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changes
+
+- Update CAPZ version to v1.9.0-gs.alpha.5 built from Giant Swarm fork (based on upstream CAPZ v1.8.2).
+
 ## [1.9.0-gs.alpha.1] - 2023-03-20
+
+### Changes
 
 - Update upstream CAPZ to use version from the fork to get gateway transit feature.
 - Revert the creationTimestamp null since it breaks installing the CRDs in a brand new cluster.

--- a/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-azure/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capz-validating-webhook-configuration.yaml
@@ -146,6 +146,7 @@ webhooks:
     apiVersions:
     - v1beta1
     operations:
+    - CREATE
     - UPDATE
     resources:
     - azuremanagedclusters
@@ -190,6 +191,7 @@ webhooks:
     apiVersions:
     - v1beta1
     operations:
+    - CREATE
     - UPDATE
     - DELETE
     resources:

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.4
+  tag: v1.9.0-gs.alpha.5
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2041

Changes:
- Use the CAPZ version from v1.9.0 gs.alpha.4 (from fork, based on CAPZ v1.8.0) to v1.9.0 gs.alpha.5 (from fork, based on CAPZ v1.8.2).
- Minor manifest changes made in upstream CAPZ bugfixes.