### PR TITLE
Use new control-plane taint toleration

### DIFF
--- a/helm/cluster-api-provider-azure/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-provider-azure/templates/crd-install/crd-job.yaml
@@ -25,6 +25,8 @@ spec:
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       containers:
       - name: kubectl
         image: "{{ .Values.crdInstall.kubectl.image }}:{{ .Values.crdInstall.kubectl.tag }}"


### PR DESCRIPTION
This PR adds a new toleration for the `node-role.kubernetes.io/control-plane` taint to occurrences where the old one already exists.
