### PR TITLE
Update to CAPZ version with fixed private endpoint deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Update CAPZ version to newer alpha version (from our fork) with private endpoints deletion fixed. 
+- Update CAPZ version to newer alpha version (from our fork) with private endpoints deletion fixed.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update CAPZ version to newer alpha version (from our fork) with private endpoints deletion fixed. 
+
 ### Added
 
 - Add new toleration for the `node-role.kubernetes.io/control-plane` taint.

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.13
+  tag: v1.9.0-gs.alpha.14
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.15
+  tag: v1.9.0-gs.alpha.16
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.14
+  tag: v1.9.0-gs.alpha.15
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.16
+  tag: v1.9.0-gs.alpha.17
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2528

This will be an alpha release of the app that is using an alpha release of the CAPZ from fork. After more testing and PR review a beta/RC will be published.