### PR TITLE
Update capz version to v1.9.0-gs.alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Add required values for pss policies.
+- Update CAPZ version to newer alpha version (from our fork) with private endpoints deletion fixed.
 
 ## [1.9.0-alpha.5] - 2023-06-19
 

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.18
+  tag: v1.9.0-gs.alpha.19
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.19
+  tag: v1.9.0-gs.alpha.20
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.17
+  tag: v1.9.0-gs.alpha.18
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Update CAPZ app to use the latest release `v1.9.0-gs.alpha.20` from our fork.

The CAPZ release from branch `release-1.8` in our fork, where on top of CAPZ we have 2 our contributions (merged PRs):
- Private links support
- Fixed private endpoints deletion

The above two changes are already present in CAPZ app, the only difference is that now, with this PR, the app will use CAPZ version from `release-1.8` branch in our fork (and not development branch anymore), so CAPZ app is using a released version of CAPZ from our fork (not development version anymore).