### PR TITLE
Upgrade CAPZ to fix private links NAT IP issue when pre-created VNet is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update CAPZ version to fix private links NAT IP configuration. 
+
 ## [1.9.0-alpha.6] - 2023-07-21
 
 ### Fixed

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: v1.9.0-gs.alpha.20
+  tag: 7bab7d8ffe7091fcfbe486ec54664c0c56a47e37
 
 project:
   branch: "[[ .Branch ]]"

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-azure-controller
 image:
   registry: quay.io
   name: giantswarm/cluster-api-azure-controller
-  tag: 7bab7d8ffe7091fcfbe486ec54664c0c56a47e37
+  tag: v1.9.0-gs.alpha.21
 
 project:
   branch: "[[ .Branch ]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2722