### PR TITLE
Adjust deployment taints and node affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add node affinity to prefer scheduling on `control-plane` nodes.
-- Remove `kustomize` patch that was cleaning `creationTimestamp`.
 - Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
 - Remove toleration for old `node-role.kubernetes.io/master` taint.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add node affinity to prefer scheduling on `control-plane` nodes.
+- Remove `kustomize` patch that was cleaning `creationTimestamp`.
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Remove toleration for old `node-role.kubernetes.io/master` taint.
+
 ## [1.9.0-alpha.8] - 2024-01-18
 
 ### Added

--- a/config/helm/deployment-affinity.yaml
+++ b/config/helm/deployment-affinity.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capz-controller-manager
+  namespace: capz-system
+spec:
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10

--- a/config/helm/deployment-toleration.yaml
+++ b/config/helm/deployment-toleration.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capz-controller-manager
+  namespace: capz-system
+spec:
+  template:
+    spec:
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -15,9 +15,11 @@ images:
 
 patchesStrategicMerge:
   - deployment-args.yaml
+  - deployment-affinity.yaml
   - deployment-environment.yaml
   - deployment-metrics-port.yaml
   - deployment-securitycontext.yaml
+  - deployment-toleration.yaml
   - webhook-certificate.yaml
   - service-prometheus-annotations.yaml
   - service-add-metrics-port.yaml
@@ -65,9 +67,3 @@ patches:
     kind: DaemonSet
     name: capz-nmi
   path: daemonset-nmi-args.yaml
-- target:
-    kind: CustomResourceDefinition
-    name: (azuremanagedmachinepools|azuremanagedcontrolplanes|azuremanagedclusters).infrastructure.cluster.x-k8s.io
-  patch: |-
-    - op: remove
-      path: /metadata/creationTimestamp

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,4 +1,4 @@
-Gnamespace: '{{ .Release.Namespace }}'
+namespace: '{{ .Release.Namespace }}'
 
 resources:
   - input/infrastructure-components.yaml

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,4 +1,4 @@
-namespace: '{{ .Release.Namespace }}'
+Gnamespace: '{{ .Release.Namespace }}'
 
 resources:
   - input/infrastructure-components.yaml
@@ -67,3 +67,9 @@ patches:
     kind: DaemonSet
     name: capz-nmi
   path: daemonset-nmi-args.yaml
+  - target:
+    kind: CustomResourceDefinition
+    name: (azuremanagedmachinepools|azuremanagedcontrolplanes|azuremanagedclusters).infrastructure.cluster.x-k8s.io
+  patch: |-
+    - op: remove
+      path: /metadata/creationTimestamp

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -67,7 +67,7 @@ patches:
     kind: DaemonSet
     name: capz-nmi
   path: daemonset-nmi-args.yaml
-  - target:
+- target:
     kind: CustomResourceDefinition
     name: (azuremanagedmachinepools|azuremanagedcontrolplanes|azuremanagedclusters).infrastructure.cluster.x-k8s.io
   patch: |-

--- a/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
+++ b/helm/cluster-api-provider-azure/templates/apps_v1_deployment_capz-controller-manager.yaml
@@ -29,6 +29,14 @@ spec:
         cluster.x-k8s.io/provider: infrastructure-azure
         control-plane: capz-controller-manager
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       containers:
       - args:
         - --leader-elect={{- if eq .Values.provider.flavor "capi" }}true{{ else }}false{{-
@@ -114,9 +122,10 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node.cluster.x-k8s.io/uninitialized
+        operator: Exists
       volumes:
       - name: cert
         secret:


### PR DESCRIPTION
### Changed

- Add node affinity to prefer scheduling on `control-plane` nodes.
- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Remove toleration for old `node-role.kubernetes.io/master` taint.

towards https://github.com/giantswarm/giantswarm/issues/30433