### PR TITLE
Use ASO image from gsoci.azurecr.io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove kube-rbac-proxy from azure-service-operator.
+- Use image of azure-service-operator from `gsoci.azurecr.io`.
 
 ## [1.12.4-gs1] - 2024-07-10
 

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -13,6 +13,8 @@ images:
   - name: registry.k8s.io/cluster-api-azure/cluster-api-azure-controller
     newName: "{{.Values.image.registry}}/{{.Values.image.name}}"
     newTag: "{{.Values.image.tag}}"
+  - name: mcr.microsoft.com/k8s/azureserviceoperator:v2.4.0
+    newName: "{{.Values.aso.image.registry}}/{{.Values.aso.image.name}}"
 
 patchesStrategicMerge:
   - deployment-capz-args.yaml

--- a/helm/cluster-api-provider-azure/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/helm/cluster-api-provider-azure/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -118,7 +118,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: mcr.microsoft.com/k8s/azureserviceoperator:v2.4.0
+        image: '{{.Values.aso.image.registry}}/{{.Values.aso.image.name}}:v2.4.0'
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/helm/cluster-api-provider-azure/values.schema.json
+++ b/helm/cluster-api-provider-azure/values.schema.json
@@ -2,6 +2,22 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "aso": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "registry": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "controller": {
             "type": "object",
             "properties": {

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -4,6 +4,11 @@ image:
   name: giantswarm/cluster-api-azure-controller
   tag: v1.12.4-gs.alpha.2
 
+aso:
+  image:
+    registry: gsoci.azurecr.io
+    name: giantswarm/azureserviceoperator
+
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"


### PR DESCRIPTION
We mirror all images to gsoci.azurecr.io and consume from there. I made a mistake and didn't overwrite the image registry&name for ASO. This PR fixes it.

I didn't make ASO tag configurable here since we need to fetch the tag from infrastructure_yaml and overwrite values.yaml of helm at that time to be able to run `make generate` safely. This seemed unnecessary to me. 

Retagger PR: https://github.com/giantswarm/retagger/pull/1029