### PR TITLE
Chart: Add `azure.workload.identity/use: "true"` label to Azure Service Operator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Chart: Add `azure.workload.identity/client-id` annotation to service accounts. ([#176](https://github.com/giantswarm/cluster-api-provider-azure-app/pull/176))
+- Chart: Add `azure.workload.identity/use: "true"` label to Azure Service Operator. ([#195](https://github.com/giantswarm/cluster-api-provider-azure-app/pull/195))
 
 ### Changed
 

--- a/config/helm/patches/deployments/azureserviceoperator-controller-manager.yaml
+++ b/config/helm/patches/deployments/azureserviceoperator-controller-manager.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: capz-system
 spec:
   template:
+    metadata:
+      labels:
+        azure.workload.identity/use: "true"
     spec:
       containers:
       - name: manager

--- a/helm/cluster-api-provider-azure/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
+++ b/helm/cluster-api-provider-azure/templates/apps_v1_deployment_azureserviceoperator-controller-manager.yaml
@@ -27,6 +27,7 @@ spec:
         aadpodidbinding: aso-manager-binding
         app.kubernetes.io/name: azure-service-operator
         app.kubernetes.io/version: v2.8.0
+        azure.workload.identity/use: "true"
         control-plane: controller-manager
     spec:
       containers:


### PR DESCRIPTION
ASO cannot use AZWI to reach azure without this label.
Part of the manual steps involved during the Wallaby migration to AZWI.
https://github.com/giantswarm/giantswarm/issues/33998#issuecomment-3160240954