### PR TITLE
Chart: Update CAPZ to v1.16.5-gs-9535f270d.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: Update CAPZ to v1.16.5-gs-9535f270d. ([#201](https://github.com/giantswarm/cluster-api-provider-azure-app/pull/201))
+
 ## [3.0.0] - 2025-08-13
 
 ### Added

--- a/helm/cluster-api-provider-azure/templates/v1_secret_aso-controller-settings.yaml
+++ b/helm/cluster-api-provider-azure/templates/v1_secret_aso-controller-settings.yaml
@@ -21,5 +21,5 @@ stringData:
   AZURE_SUBSCRIPTION_ID: '{{ .Values.provider.subscriptionId }}'
   AZURE_SYNC_PERIOD: ""
   AZURE_TENANT_ID: '{{ .Values.provider.tenantId }}'
-  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/v1.16.5-gs-0a602128d
+  AZURE_USER_AGENT_SUFFIX: cluster-api-provider-azure/v1.16.5-gs-9535f270d
 type: Opaque

--- a/helm/cluster-api-provider-azure/values.yaml
+++ b/helm/cluster-api-provider-azure/values.yaml
@@ -12,7 +12,7 @@ image:
   # -- Image repository.
   name: giantswarm/cluster-api-azure-controller
   # -- Image tag.
-  tag: v1.16.5-gs-0a602128d
+  tag: v1.16.5-gs-9535f270d
 
 # -- Azure Service Operator settings.
 aso:


### PR DESCRIPTION
This version of the image fixes an issue with Private Endpoint deletion.