### PR TITLE
chore: update cluster-api-provider-azure to v1.23.0-gs-c0faf6a76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Chart: don't specify rules in aggregated cluster role.
+
 ## [4.2.1] - 2026-07-02
 
 ### Changed

--- a/helm/cluster-api-provider-azure/Chart.yaml
+++ b/helm/cluster-api-provider-azure/Chart.yaml
@@ -11,7 +11,7 @@ version: 4.2.1
 # * Giant Swarm README and GitHub Workflows (https://github.com/giantswarm/cluster-api-provider-azure/pull/123)
 # * Add Private Link support (https://github.com/giantswarm/cluster-api-provider-azure/pull/124)
 # * Fix RBAC for OwnerReferencesPermissionEnforcement feature (https://github.com/giantswarm/cluster-api-provider-azure/pull/125)
-appVersion: v1.23.0-gs-dd9dbf924
+appVersion: v1.23.0-gs-c0faf6a76
 home: https://github.com/giantswarm/cluster-api-provider-azure-app
 icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 annotations:

--- a/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
+++ b/helm/cluster-api-provider-azure/templates/rbac.authorization.k8s.io_v1_clusterrole_capz-manager-role.yaml
@@ -15,4 +15,3 @@ metadata:
     cluster.x-k8s.io/provider: infrastructure-azure
     helm.sh/chart: cluster-api-provider-azure
   name: capz-manager-role
-rules: []


### PR DESCRIPTION
fix: don't specify rules in aggregated cluster role